### PR TITLE
Add GHolo Converter

### DIFF
--- a/src/main/java/eu/decentsoftware/holograms/plugin/commands/HologramsCommand.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/commands/HologramsCommand.java
@@ -8,6 +8,7 @@ import eu.decentsoftware.holograms.api.utils.Common;
 import eu.decentsoftware.holograms.api.utils.message.Message;
 import eu.decentsoftware.holograms.plugin.Validator;
 import eu.decentsoftware.holograms.plugin.convertors.ConvertorType;
+import eu.decentsoftware.holograms.plugin.convertors.GHoloConverter;
 import eu.decentsoftware.holograms.plugin.convertors.HolographicDisplaysConvertor;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -263,17 +264,31 @@ public class HologramsCommand extends DecentCommand {
             return (sender, args) -> {
                 final ConvertorType convertorType = ConvertorType.fromString(args[0]);
                 final String path = args.length >= 2 ? args[0] : null;
+                
+                if (convertorType == null) {
+                    Common.tell(sender, "%s&cCannot convert Holograms! Unknown plugin '%s' provided", Common.PREFIX, args[0]);
+                    return true;
+                }
 
                 switch (convertorType) {
                     case HOLOGRAPHIC_DISPLAYS:
-                        Common.tell(sender, Common.PREFIX + "Converting from " + convertorType.getName());
+                        Common.tell(sender, "%sConverting from %s", Common.PREFIX, convertorType.getName());
                         if (path != null) {
                             File file = new File(path);
-                            new HolographicDisplaysConvertor().convert(file);
+                            return new HolographicDisplaysConvertor().convert(file);
                         } else {
-                            new HolographicDisplaysConvertor().convert();
+                            return new HolographicDisplaysConvertor().convert();
                         }
-                        return true;
+                    
+                    case GHOLO:
+                        Common.tell(sender, "%sConverting from %s", Common.PREFIX, convertorType.getName());
+                        if (path != null) {
+                            File file = new File(path);
+                            return new GHoloConverter().convert(file);
+                        } else {
+                            return new GHoloConverter().convert();
+                        }
+                        
                     default:
                         break;
                 }

--- a/src/main/java/eu/decentsoftware/holograms/plugin/convertors/ConverterCommon.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/convertors/ConverterCommon.java
@@ -1,0 +1,28 @@
+package eu.decentsoftware.holograms.plugin.convertors;
+
+import eu.decentsoftware.holograms.api.DecentHolograms;
+import eu.decentsoftware.holograms.api.holograms.Hologram;
+import eu.decentsoftware.holograms.api.holograms.HologramLine;
+import eu.decentsoftware.holograms.api.holograms.HologramPage;
+import eu.decentsoftware.holograms.api.utils.Common;
+import org.bukkit.Location;
+
+import java.util.List;
+import java.util.logging.Level;
+
+public class ConverterCommon {
+    
+    public static int createHologram(int count, String name, Location location, List<String> lines, DecentHolograms plugin){
+        if (plugin.getHologramManager().containsHologram(name)) {
+            Common.log(Level.WARNING, "A hologram with name '%s' already exists, skipping...", name);
+            return count;
+        }
+        Hologram hologram = new Hologram(name, location);
+        HologramPage page = hologram.getPage(0);
+        plugin.getHologramManager().registerHologram(hologram);
+        lines.forEach((line) -> page.addLine(new HologramLine(page, page.getNextLineLocation(), line)));
+        hologram.save();
+        count++;
+        return count;
+    }
+}

--- a/src/main/java/eu/decentsoftware/holograms/plugin/convertors/ConvertorType.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/convertors/ConvertorType.java
@@ -4,11 +4,12 @@ import java.util.Arrays;
 import java.util.List;
 
 public enum ConvertorType {
-	HOLOGRAPHIC_DISPLAYS("HolographicDisplays", "DH", "hd");
+	HOLOGRAPHIC_DISPLAYS("HolographicDisplays", "DH", "hd"),
+	GHOLO("GHolo", "gholo", "gh");
 
 	public static ConvertorType fromString(String alias) {
 		for (ConvertorType convertorType : ConvertorType.values()) {
-			if (convertorType.getName().equals(alias) || convertorType.getAliases().contains(alias)) {
+			if (convertorType.getName().equalsIgnoreCase(alias) || convertorType.getAliases().contains(alias)) {
 				return convertorType;
 			}
 		}

--- a/src/main/java/eu/decentsoftware/holograms/plugin/convertors/GHoloConverter.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/convertors/GHoloConverter.java
@@ -1,0 +1,86 @@
+package eu.decentsoftware.holograms.plugin.convertors;
+
+import eu.decentsoftware.holograms.api.DecentHolograms;
+import eu.decentsoftware.holograms.api.DecentHologramsAPI;
+import eu.decentsoftware.holograms.api.convertor.IConvertor;
+import eu.decentsoftware.holograms.api.holograms.Hologram;
+import eu.decentsoftware.holograms.api.holograms.HologramLine;
+import eu.decentsoftware.holograms.api.holograms.HologramPage;
+import eu.decentsoftware.holograms.api.utils.Common;
+import eu.decentsoftware.holograms.api.utils.config.Configuration;
+import eu.decentsoftware.holograms.api.utils.location.LocationUtils;
+import org.bukkit.Location;
+
+import java.io.File;
+import java.util.List;
+import java.util.Locale;
+import java.util.logging.Level;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class GHoloConverter implements IConvertor {
+    
+    private static final DecentHolograms PLUGIN = DecentHologramsAPI.get();
+    private static final Pattern GRADIENT = Pattern.compile("\\[(#[0-9a-f]{6}) (\\w+) (#[0-9a-f]{6})]", Pattern.CASE_INSENSITIVE);
+    
+    @Override
+    public boolean convert(){
+        return convert(new File("plugins/GHolo/data/h.data"));
+    }
+    
+    @Override
+    public boolean convert(File file) {
+        Common.log("Converting GHolo holograms...");
+        if (!this.isFileValid(file)) {
+            Common.log("Invalid file! Need 'h.data'");
+            return false;
+        }
+        int count = 0;
+        Configuration config = new Configuration(PLUGIN.getPlugin(), file);
+        for (String name : config.getConfigurationSection("H").getKeys(false)) {
+            Location location =parseLocation(config.getString(name + ".l"));
+            List<String> lines = prepareLines(config.getStringList(name + ".c"));
+            
+            count = ConverterCommon.createHologram(count, name, location, lines, PLUGIN);
+        }
+        Common.log("Successfully converted %d GHolo holograms!", count);
+        return true;
+    }
+    
+    @Override
+    public boolean convert(File... files) {
+        for (File file : files) {
+            this.convert(file);
+        }
+        return true;
+    }
+    
+    private boolean isFileValid(final File file) {
+        return file != null && file.exists() && !file.isDirectory() && file.getName().equals("h.data");
+    }
+    
+    private Location parseLocation(final String locationString) {
+        return LocationUtils.asLocation(locationString);
+    }
+    
+    private List<String> prepareLines(List<String> lines) {
+        return lines.stream().map(line -> {
+            line = line.replace("[x]", "\u2588");
+            line = line.replace("[|]", "\u23B9");
+            if (line.toUpperCase(Locale.ROOT).startsWith("ICON:") || line.toUpperCase(Locale.ROOT).startsWith("ENTITY:")) {
+                return "#" + line;
+            }
+            Matcher matcher = GRADIENT.matcher(line);
+            if (matcher.find()) {
+                StringBuffer temp = new StringBuffer();
+                do {
+                    matcher.appendReplacement(temp, "<" + matcher.group(1) + ">" + matcher.group(2) + "</" + matcher.group(3) + ">");
+                } while (matcher.find());
+                matcher.appendTail(temp);
+                return temp.toString();
+            }
+            return line;
+        }).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/eu/decentsoftware/holograms/plugin/convertors/HolographicDisplaysConvertor.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/convertors/HolographicDisplaysConvertor.java
@@ -38,17 +38,8 @@ public class HolographicDisplaysConvertor implements IConvertor {
 		for (String name : config.getKeys(false)) {
 			Location location = parseLocation(config.getString(name + ".location"));
 			List<String> lines = prepareLines(config.getStringList(name + ".lines"));
-
-			if (PLUGIN.getHologramManager().containsHologram(name)) {
-				Common.log(Level.WARNING, "A hologram with name '%s' already exists, skipping...");
-				continue;
-			}
-			Hologram hologram = new Hologram(name, location);
-			HologramPage page = hologram.getPage(0);
-			PLUGIN.getHologramManager().registerHologram(hologram);
-			lines.forEach((line) -> page.addLine(new HologramLine(page, page.getNextLineLocation(), line)));
-			hologram.save();
-			count++;
+			
+			count = ConverterCommon.createHologram(count, name, location, lines, PLUGIN);
 		}
 		Common.log("Successfully converted %d HolographicDisplays holograms!", count);
 		return true;


### PR DESCRIPTION
Adds [`GHolo`](https://www.spigotmc.org/resources/70913/) as a possible convertion option to `/dh convert`

Changes:
- Moved common code for Hologram creation to a new class called `ConverterCommon` (Static class returning an integer.
- Added null-check for ConverterType to make sure the Converter actually exists.
- Fixed/Prevented a possible exception for the "Hologram already exists" message. It had a `%s` but no replacement value.
- Improved readability of other messages.

On another note: Not a big fan of how I implemented the possible gradient conversion (Actually, from my tests of GHolo does that pattern not even work?), so if you have a better way of converting this, let me know.

I also didn't bother trying to also convert the animations (Mainly because HD Converter also doesn't have this)