### PR TITLE
Fix GHolo convertion

### DIFF
--- a/src/main/java/eu/decentsoftware/holograms/api/utils/location/LocationUtils.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/utils/location/LocationUtils.java
@@ -10,6 +10,8 @@ import org.bukkit.World;
 import org.bukkit.util.NumberConversions;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.UUID;
+
 @UtilityClass
 public class LocationUtils {
 
@@ -35,7 +37,7 @@ public class LocationUtils {
 		String[] spl = string.replace(",", ".").split(":");
 		Location location;
 		if (spl.length >= 4) {
-			World world = Bukkit.getWorld(spl[0]);
+			World world = getWorld(spl[0]);
 			if (world != null) {
 				try {
 					location = new Location(world, Double.parseDouble(spl[1]), Double.parseDouble(spl[2]), Double.parseDouble(spl[3]));
@@ -63,6 +65,16 @@ public class LocationUtils {
 
 	public static double distance2D(@NonNull Location location1, @NonNull Location location2) {
 		return Math.sqrt(NumberConversions.square(location1.getX() - location2.getX()) + NumberConversions.square(location1.getZ() - location2.getZ()));
+	}
+	
+	// Plugins like GHolo use the world's UUID instead of the name for location.
+	private static World getWorld(@NonNull String value) {
+		UUID uuid = null;
+		try {
+			uuid = UUID.fromString(value);
+		} catch (IllegalArgumentException ignored) {}
+		
+		return uuid == null ? Bukkit.getWorld(value) : Bukkit.getWorld(uuid);
 	}
 
 }

--- a/src/main/java/eu/decentsoftware/holograms/plugin/convertors/GHoloConverter.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/convertors/GHoloConverter.java
@@ -35,8 +35,10 @@ public class GHoloConverter implements IConvertor {
         int count = 0;
         Configuration config = new Configuration(PLUGIN.getPlugin(), file);
         for (String name : config.getConfigurationSection("H").getKeys(false)) {
-            Location location = parseLocation(config.getString(name + ".l"));
-            List<String> lines = prepareLines(config.getStringList(name + ".c"));
+            String path = "H." + name;
+            
+            Location location = LocationUtils.asLocation(config.getString(path + ".l"));
+            List<String> lines = prepareLines(config.getStringList(path + ".c"));
             
             count = ConverterCommon.createHologram(count, name, location, lines, PLUGIN);
         }
@@ -54,10 +56,6 @@ public class GHoloConverter implements IConvertor {
     
     private boolean isFileValid(final File file) {
         return file != null && file.exists() && !file.isDirectory() && file.getName().equals("h.data");
-    }
-    
-    private Location parseLocation(final String locationString) {
-        return LocationUtils.asLocation(locationString);
     }
     
     private List<String> prepareLines(List<String> lines) {


### PR DESCRIPTION
The issue was, that the path missed the `H.` part at the start.

Also, GHolo's latest release now uses UUIDs instead of world names, but to still support both did I make a `getWorld` method in the LocationUtils class which will try to create a UUID from the String and if it fails, go back to getting the world by name instead.

I made some tests and the command worked flawlessly for me... Well... The holograms where a bit further down than what the GHolo ones are, but conversion works!