### PR TITLE
Fixed NPE when using /dh pages help

### DIFF
--- a/src/main/java/eu/decentsoftware/holograms/plugin/commands/PageSubCommand.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/commands/PageSubCommand.java
@@ -90,7 +90,7 @@ public class PageSubCommand extends DecentCommand {
                 Common.tell(sender, " &3&lHOLOGRAM PAGES HELP");
                 Common.tell(sender, " All page commands.");
                 sender.sendMessage("");
-                CommandBase command = PLUGIN.getCommandManager().getMainCommand().getSubCommand("page");
+                CommandBase command = PLUGIN.getCommandManager().getMainCommand().getSubCommand("pages");
                 List<CommandBase> subCommands = Lists.newArrayList(command.getSubCommands());
                 for (CommandBase subCommand : subCommands) {
                     Common.tell(sender, " &8• &b%s &8- &7%s", subCommand.getUsage(), subCommand.getDescription());


### PR DESCRIPTION
Whenever using /dh pages help, you would run into an NPE.

Fixes this issue:
[https://paste.gg/p/anonymous/54301156d9e54de6b67d0a6f933703fd](https://paste.gg/p/anonymous/54301156d9e54de6b67d0a6f933703fd)

This is fixed via using the correct subCommand name. Previously it was "page," which does not correlate to BaseCommand name "pages."