### PR TITLE
Fix(?) possible NPE for show(Player...)

### DIFF
--- a/src/main/java/eu/decentsoftware/holograms/api/holograms/HologramLine.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/holograms/HologramLine.java
@@ -309,6 +309,10 @@ public class HologramLine extends HologramObject {
         List<Player> playerList = getPlayers(false, players);
         NMS nms = NMS.getInstance();
         for (Player player : playerList) {
+            if (player == null) {
+                continue;
+            }
+            
             if (!isVisible(player) && canShow(player) && isInDisplayRange(player)) {
                 switch (type) {
                     case TEXT:


### PR DESCRIPTION
To be honest: I don't think this is a proper solution to fix this...

But this would (hopefully) prevent a NPE for the `show(Player...)` method in the `HologramLine` class by essentially skipping null player entries.

I feel like it should be looked into preventing the creation of null Player instances to begin with...