### PR TITLE
Improve handling of null/invalid locations in Hologram converters

### DIFF
--- a/src/main/java/eu/decentsoftware/holograms/api/utils/file/FileUtils.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/utils/file/FileUtils.java
@@ -24,7 +24,7 @@ public class FileUtils {
         if (dir.exists() && dir.isDirectory()) {
             return dir.list((dir1, name) -> regex == null || regex.trim().isEmpty() || name.matches(regex));
         } else if (createDir && dir.mkdirs()) {
-            Common.log("Created directory " + path);
+            Common.log("Created directory %s", path);
         }
         return new String[0];
     }

--- a/src/main/java/eu/decentsoftware/holograms/api/utils/file/FileUtils.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/utils/file/FileUtils.java
@@ -1,5 +1,6 @@
 package eu.decentsoftware.holograms.api.utils.file;
 
+import eu.decentsoftware.holograms.api.utils.Common;
 import lombok.experimental.UtilityClass;
 
 import javax.annotation.Nonnull;
@@ -18,13 +19,12 @@ public class FileUtils {
         return getFileNames(path, regex, false);
     }
 
-    @Nonnull
     public static String[] getFileNames(String path, String regex, boolean createDir) {
         File dir = new File(path);
         if (dir.exists() && dir.isDirectory()) {
             return dir.list((dir1, name) -> regex == null || regex.trim().isEmpty() || name.matches(regex));
-        } else if (createDir) {
-            dir.mkdirs();
+        } else if (createDir && dir.mkdirs()) {
+            Common.log("Created directory " + path);
         }
         return new String[0];
     }

--- a/src/main/java/eu/decentsoftware/holograms/api/utils/location/LocationUtils.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/utils/location/LocationUtils.java
@@ -1,5 +1,6 @@
 package eu.decentsoftware.holograms.api.utils.location;
 
+import eu.decentsoftware.holograms.api.utils.Common;
 import eu.decentsoftware.holograms.api.utils.RandomUtils;
 import eu.decentsoftware.holograms.api.utils.exception.LocationParseException;
 import lombok.NonNull;
@@ -11,6 +12,7 @@ import org.bukkit.util.NumberConversions;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
+import java.util.logging.Level;
 
 @UtilityClass
 public class LocationUtils {
@@ -27,9 +29,9 @@ public class LocationUtils {
 		try {
 			return asLocationE(string);
 		} catch (LocationParseException e) {
-			e.printStackTrace();
+			Common.log(Level.WARNING, "Error while parsing Location %s: %s", string, e.getMessage());
+			return null;
 		}
-		return null;
 	}
 
 	public static Location asLocationE(String string) throws LocationParseException {

--- a/src/main/java/eu/decentsoftware/holograms/plugin/convertors/CMIConverter.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/convertors/CMIConverter.java
@@ -12,6 +12,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 public class CMIConverter implements IConvertor {
@@ -33,13 +34,18 @@ public class CMIConverter implements IConvertor {
         int count = 0;
         Configuration config = new Configuration(PLUGIN.getPlugin(), file);
         for(String name : config.getKeys(false)) {
-            // Auto-generated holograms to change pages.
+            // Skip Auto-generated holograms to change pages.
             if(name.endsWith("#>") || name.endsWith("#<")) {
-                Common.log("Skipping auto-generated next/prev page holograms...");
+                Common.log("Skipping auto-generated next/prev page hologram '%s'...", name);
                 continue;
             }
             
             Location loc = LocationUtils.asLocation(config.getString(name + ".Loc").replace(";", ":"));
+            if(loc == null){
+                Common.log(Level.WARNING, "Skipping hologram '%s' with null location...", name);
+                continue;
+            }
+            
             List<List<String>> pages = createPages(config.getStringList(name + ".Lines"));
             
             count = ConverterCommon.createHologramPages(count, name, loc, pages, PLUGIN);

--- a/src/main/java/eu/decentsoftware/holograms/plugin/convertors/GHoloConverter.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/convertors/GHoloConverter.java
@@ -11,6 +11,7 @@ import org.bukkit.Location;
 import java.io.File;
 import java.util.List;
 import java.util.Locale;
+import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -38,6 +39,11 @@ public class GHoloConverter implements IConvertor {
             String path = "H." + name;
             
             Location location = LocationUtils.asLocation(config.getString(path + ".l"));
+            if(location == null){
+                Common.log(Level.WARNING, "Skipping hologram '%s' with null location...", name);
+                continue;
+            }
+            
             List<String> lines = prepareLines(config.getStringList(path + ".c"));
             
             count = ConverterCommon.createHologram(count, name, location, lines, PLUGIN);

--- a/src/main/java/eu/decentsoftware/holograms/plugin/convertors/HolographicDisplaysConvertor.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/convertors/HolographicDisplaysConvertor.java
@@ -36,7 +36,7 @@ public class HolographicDisplaysConvertor implements IConvertor {
 		for (String name : config.getKeys(false)) {
 			Location location = parseLocation(config, name);
 			if(location == null){
-				Common.log(Level.WARNING, "Location for '%s' was null. Skipping...", name);
+				Common.log(Level.WARNING, "Skipping hologram '%s' with null location...", name);
 				continue;
 			}
 			

--- a/src/main/java/eu/decentsoftware/holograms/plugin/convertors/HolographicDisplaysConvertor.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/convertors/HolographicDisplaysConvertor.java
@@ -11,6 +11,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
 
 import java.io.File;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 public class HolographicDisplaysConvertor implements IConvertor {
@@ -34,6 +35,11 @@ public class HolographicDisplaysConvertor implements IConvertor {
 		Configuration config = new Configuration(PLUGIN.getPlugin(), file);
 		for (String name : config.getKeys(false)) {
 			Location location = parseLocation(config, name);
+			if(location == null){
+				Common.log(Level.WARNING, "Location for '%s' was null. Skipping...", name);
+				continue;
+			}
+			
 			List<String> lines = prepareLines(config.getStringList(name + ".lines"));
 			
 			count = ConverterCommon.createHologram(count, name, location, lines, PLUGIN);


### PR DESCRIPTION
This PR improves the way locations are parsed.

Instead of printing the exception, which may break stuff such as converters (See [this message](https://discord.com/channels/850844430830534696/899603466270441492/941719166396813382) on Discord for further details) will the LocationUtils class now simply catch the exception, print a warning with the exception message/reason and return null.

This allows the converters, which also have a null check now to skip those holograms, to continue working without major issues.

(Also has a minor change for the FileUtils regarding folder creation... Just to reduce IDE warns)