### PR TITLE
Fix Hologram error for non-existant holograms

### DIFF
--- a/src/main/java/eu/decentsoftware/holograms/plugin/commands/HologramSubCommand.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/commands/HologramSubCommand.java
@@ -921,22 +921,22 @@ public class HologramSubCommand extends DecentCommand {
 					return matches;
 				} else if (args.length == 2 && Validator.isPlayer(sender)) {
 					hologram = PLUGIN.getHologramManager().getHologram(args[0]);
-					location = hologram.getLocation();
-					if (hologram != null) {
+					location = hologram == null ? null : hologram.getLocation();
+					if (location != null) {
 						return Lists.newArrayList(String.valueOf(location.getX()), "~");
 					}
 					return Lists.newArrayList(String.valueOf(((Player) sender).getLocation().getX()));
 				} else if (args.length == 3 && Validator.isPlayer(sender)) {
 					hologram = PLUGIN.getHologramManager().getHologram(args[0]);
-					location = hologram.getLocation();
-					if (hologram != null) {
+					location = hologram == null ? null : hologram.getLocation();
+					if (location != null) {
 						return Lists.newArrayList(String.valueOf(location.getY()), "~");
 					}
 					return Lists.newArrayList(String.valueOf(((Player) sender).getLocation().getY()));
 				} else if (args.length == 4 && Validator.isPlayer(sender)) {
 					hologram = PLUGIN.getHologramManager().getHologram(args[0]);
-					location = hologram.getLocation();
-					if (hologram != null) {
+					location = hologram == null ? null : hologram.getLocation();
+					if (location != null) {
 						return Lists.newArrayList(String.valueOf(location.getZ()), "~");
 					}
 					return Lists.newArrayList(String.valueOf(((Player) sender).getLocation().getZ()));


### PR DESCRIPTION
Tab-completing coordinates in the `/dh move` command while the target hologram doesn't exist, prints an error in the console.

See [this message](https://discord.com/channels/850844430830534696/899603466270441492/941723670840229889) on Discord for full context.

This PR fixes it, by making the location null, if the hologram is, followed by checking the location to not be null to apply the coordinates.