### PR TITLE
Fix IllegalArgumentException for insert command

### DIFF
--- a/src/main/java/eu/decentsoftware/holograms/api/DHAPI.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/DHAPI.java
@@ -228,7 +228,7 @@ public final class DHAPI {
      * Insert a new hologram page on the specified index into hologram.
      *
      * @param hologram The hologram.
-     * @param index The index.
+     * @param index The index. Index starts at 1.
      * @param lines New pages lines.
      * @return The new page.
      * @throws IllegalArgumentException If hologram is null or the index is out of bounds.

--- a/src/main/java/eu/decentsoftware/holograms/api/holograms/Hologram.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/holograms/Hologram.java
@@ -540,12 +540,12 @@ public class Hologram extends UpdatingHologramObject implements ITicked {
     }
 
     public HologramPage insertPage(int index) {
-        if (index < 0 || index > size()) return null;
+        if (index < 1 || index > size()) return null;
         HologramPage page = new HologramPage(this, index);
         pages.add(index, page);
 
         // Add 1 to indexes of all the other pages.
-        pages.stream().skip(index).forEach(p -> p.setIndex(p.getIndex() + 1));
+        pages.stream().skip(index - 1).forEach(p -> p.setIndex(p.getIndex() + 1));
         // Add 1 to all page indexes of current viewers, so they still see the same page.
         viewerPages.replaceAll((uuid, integer) -> {
             if (integer > index) {

--- a/src/main/java/eu/decentsoftware/holograms/api/holograms/Hologram.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/holograms/Hologram.java
@@ -545,7 +545,7 @@ public class Hologram extends UpdatingHologramObject implements ITicked {
         pages.add(index, page);
 
         // Add 1 to indexes of all the other pages.
-        pages.stream().skip(index - 1).forEach(p -> p.setIndex(p.getIndex() + 1));
+        pages.stream().skip(index).forEach(p -> p.setIndex(p.getIndex() + 1));
         // Add 1 to all page indexes of current viewers, so they still see the same page.
         viewerPages.replaceAll((uuid, integer) -> {
             if (integer > index) {

--- a/src/main/java/eu/decentsoftware/holograms/plugin/commands/PageSubCommand.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/commands/PageSubCommand.java
@@ -185,7 +185,7 @@ public class PageSubCommand extends DecentCommand {
         public CommandHandler getCommandHandler() {
             return (sender, args) -> {
                 Hologram hologram = Validator.getHologram(args[0], Lang.HOLOGRAM_DOES_NOT_EXIST.getValue());
-                HologramPage page = hologram.insertPage(Validator.getInteger(args[1], Lang.PAGE_DOES_NOT_EXIST.getValue()) - 1);
+                HologramPage page = hologram.insertPage(Validator.getInteger(args[1], Lang.PAGE_DOES_NOT_EXIST.getValue()));
                 if (page != null) {
                     String content = Settings.DEFAULT_TEXT.getValue();
                     if (args.length > 2) {


### PR DESCRIPTION


When using `/dh page insert <hologram> <page> <content>` does DH throw an IllegalArgumentException, if the value is 1.

The issue is, that DH is removing 1 integer value **twice** when using the command: Once on command handling and once in the `insertPage` method when `pages.stream().skip(int)` is used.

The PR fixes this in the following ways:

- Removes the `- 1` from the command handling to instead pass the provided integer value.
- Change `index < 0` to `index < 1` to support the above changes. This could break existing DHAPI usages, but considering that as of now, any usage of `0` would lead to the exact same result is this debatable.