### PR TITLE
Add overloads for ItemStack and Material to DHAPI

### DIFF
--- a/src/main/java/eu/decentsoftware/holograms/api/DHAPI.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/DHAPI.java
@@ -314,22 +314,24 @@ public final class DHAPI {
      * Add a new line with an item into hologram.
      * 
      * @param hologram The hologram.
-     * @param material Item material to add as content.
+     * @param material Material for new line content.
      * @return The new line.
      * @throws IllegalArgumentException If hologram or material is null
      */
     public static HologramLine addHologramLine(Hologram hologram, Material material) throws IllegalArgumentException {
+        Validate.notNull(material);
         return addHologramLine(hologram, new ItemStack(material));
     }
     
     /**
      * Add an ItemStack as new line into hologram.
-     * @param hologram
-     * @param item
-     * @return
-     * @throws IllegalArgumentException
+     * @param hologram The hologram.
+     * @param item ItemStack for new line content.
+     * @return The new line.
+     * @throws IllegalArgumentException If hologram or item is null
      */
     public static HologramLine addHologramLine(Hologram hologram, ItemStack item) throws IllegalArgumentException {
+        Validate.notNull(item);
         return addHologramLine(hologram, "#ICON:" + HologramItem.fromItemStack(item).getContent());
     }
     

--- a/src/main/java/eu/decentsoftware/holograms/api/DHAPI.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/DHAPI.java
@@ -3,9 +3,12 @@ package eu.decentsoftware.holograms.api;
 import eu.decentsoftware.holograms.api.holograms.Hologram;
 import eu.decentsoftware.holograms.api.holograms.HologramLine;
 import eu.decentsoftware.holograms.api.holograms.HologramPage;
+import eu.decentsoftware.holograms.api.utils.items.HologramItem;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -306,7 +309,30 @@ public final class DHAPI {
         Validate.notNull(page);
         return page.getLine(index);
     }
-
+    
+    /**
+     * Add a new line with an item into hologram.
+     * 
+     * @param hologram The hologram.
+     * @param material Item material to add as content.
+     * @return The new line.
+     * @throws IllegalArgumentException If hologram or material is null
+     */
+    public static HologramLine addHologramLine(Hologram hologram, Material material) throws IllegalArgumentException {
+        return addHologramLine(hologram, new ItemStack(material));
+    }
+    
+    /**
+     * Add an ItemStack as new line into hologram.
+     * @param hologram
+     * @param item
+     * @return
+     * @throws IllegalArgumentException
+     */
+    public static HologramLine addHologramLine(Hologram hologram, ItemStack item) throws IllegalArgumentException {
+        return addHologramLine(hologram, "#ICON:" + HologramItem.fromItemStack(item).getContent());
+    }
+    
     /**
      * Add a new line into hologram.
      *
@@ -337,7 +363,33 @@ public final class DHAPI {
         }
         return addHologramLine(page, content);
     }
-
+    
+    /**
+     * Add a Material as a new line into hologram page.
+     * 
+     * @param page The page.
+     * @param material Material for new line content.
+     * @return The new line.
+     * @throws IllegalArgumentException If page or material is null
+     */
+    public static HologramLine addHologramLine(HologramPage page, Material material) throws IllegalArgumentException {
+        Validate.notNull(material);
+        return addHologramLine(page, new ItemStack(material));
+    }
+    
+    /**
+     * Add an ItemStack as a new line into hologram page.
+     *
+     * @param page The page.
+     * @param item ItemStack for new line content.
+     * @return The new line.
+     * @throws IllegalArgumentException If page or item is null
+     */
+    public static HologramLine addHologramLine(HologramPage page, ItemStack item) throws IllegalArgumentException {
+        Validate.notNull(item);
+        return addHologramLine(page, "#ICON:" + HologramItem.fromItemStack(item).getContent());
+    }
+    
     /**
      * Add a new line into hologram page.
      *
@@ -352,7 +404,35 @@ public final class DHAPI {
         page.getParent().save();
         return line;
     }
-
+    
+    /**
+     * Insert a Material as new line on the specified index into hologram page.
+     *
+     * @param hologram The hologram.
+     * @param lineIndex Index of the new line.
+     * @param material Material for new item line content.
+     * @return The new line.
+     * @throws IllegalArgumentException If hologram or material is null or the indexes are invalid.
+     */
+    public static HologramLine insertHologramLine(Hologram hologram, int lineIndex, Material material) throws IllegalArgumentException {
+        Validate.notNull(material);
+        return insertHologramLine(hologram, lineIndex, new ItemStack(material));
+    }
+    
+    /**
+     * Insert an ItemStack as new line on the specified index into hologram page.
+     *
+     * @param hologram The hologram.
+     * @param lineIndex Index of the new line.
+     * @param item ItemStack for new item line content.
+     * @return The new line.
+     * @throws IllegalArgumentException If hologram or item is null or the indexes are invalid.
+     */
+    public static HologramLine insertHologramLine(Hologram hologram, int lineIndex, ItemStack item) throws IllegalArgumentException {
+        Validate.notNull(item);
+        return insertHologramLine(hologram, 0, lineIndex, item);
+    }
+    
     /**
      * Insert a new line on the specified index into hologram page.
      *
@@ -364,6 +444,36 @@ public final class DHAPI {
      */
     public static HologramLine insertHologramLine(Hologram hologram, int lineIndex, String content) throws IllegalArgumentException {
         return insertHologramLine(hologram, 0, lineIndex, content);
+    }
+    
+    /**
+     * Insert a Material as new line on the specified index into hologram page.
+     *
+     * @param hologram The hologram.
+     * @param pageIndex Index of the hologram page.
+     * @param lineIndex Index of the new line.
+     * @param material Material for the new line content.
+     * @return The new line.
+     * @throws IllegalArgumentException If hologram or material is null or the indexes are invalid.
+     */
+    public static HologramLine insertHologramLine(Hologram hologram, int pageIndex, int lineIndex, Material material) throws IllegalArgumentException {
+        Validate.notNull(material);
+        return insertHologramLine(hologram, pageIndex, lineIndex, new ItemStack(material));
+    }
+    
+    /**
+     * Insert an ItemStack as new line on the specified index into hologram page.
+     *
+     * @param hologram The hologram.
+     * @param pageIndex Index of the hologram page.
+     * @param lineIndex Index of the new line.
+     * @param item ItemStack for the new line content.
+     * @return The new line.
+     * @throws IllegalArgumentException If hologram or item is null or the indexes are invalid.
+     */
+    public static HologramLine insertHologramLine(Hologram hologram, int pageIndex, int lineIndex, ItemStack item) throws IllegalArgumentException {
+        Validate.notNull(item);
+        return insertHologramLine(hologram, pageIndex, lineIndex, "#ICON:" + HologramItem.fromItemStack(item).getContent());
     }
 
     /**
@@ -384,7 +494,35 @@ public final class DHAPI {
         }
         return insertHologramLine(page, lineIndex, content);
     }
-
+    
+    /**
+     * Insert a Material as new line on the specified index into hologram page.
+     * 
+     * @param page The page.
+     * @param index Index of the new line.
+     * @param material Material as new line content.
+     * @return The new line.
+     * @throws IllegalArgumentException If page or material is null or the indexes are invalid.
+     */
+    public static HologramLine insertHologramLine(HologramPage page, int index, Material material) throws IllegalArgumentException {
+        Validate.notNull(material);
+        return insertHologramLine(page, index, new ItemStack(material));
+    }
+    
+    /**
+     * Insert an ItemStack as new line on the specified index into hologram page.
+     *
+     * @param page The page.
+     * @param index Index of the new line.
+     * @param item ItemStack as new line content.
+     * @return The new line.
+     * @throws IllegalArgumentException If page or item is null or the indexes are invalid.
+     */
+    public static HologramLine insertHologramLine(HologramPage page, int index, ItemStack item) throws IllegalArgumentException {
+        Validate.notNull(item);
+        return insertHologramLine(page, index, "#ICON:" + HologramItem.fromItemStack(item).getContent());
+    }
+    
     /**
      * Insert a new line on the specified index into hologram page.
      *
@@ -404,7 +542,31 @@ public final class DHAPI {
         page.getParent().save();
         return line;
     }
-
+    
+    /**
+     * Set a material as new content to a hologram line and update it.
+     * 
+     * @param line The line.
+     * @param material Material to set as new content.
+     * @throws IllegalArgumentException If any of the arguments are null.
+     */
+    public static void setHologramLine(HologramLine line, Material material) throws IllegalArgumentException {
+        Validate.notNull(material);
+        setHologramLine(line, new ItemStack(material));
+    }
+    
+    /**
+     * Set an ItemStack as new content to a hologram line and update it.
+     * 
+     * @param line The line.
+     * @param item ItemStack to set as new content.
+     * @throws IllegalArgumentException If any of the arguments are null
+     */
+    public static void setHologramLine(HologramLine line, ItemStack item) throws IllegalArgumentException {
+        Validate.notNull(item);
+        setHologramLine(line, "#ICON:" + HologramItem.fromItemStack(item).getContent());
+    }
+    
     /**
      * Set a new content to hologram line and update it.
      *
@@ -436,6 +598,32 @@ public final class DHAPI {
             parent.getParent().save();
         }
     }
+    
+    /**
+     * Set a Material as new content to hologram line and update it.
+     *
+     * @param page The parent page.
+     * @param lineIndex The index of the line.
+     * @param material Material for new content.
+     * @throws IllegalArgumentException If any of the arguments are null or the indexes are invalid.
+     */
+    public static void setHologramLine(HologramPage page, int lineIndex, Material material) throws IllegalArgumentException {
+        Validate.notNull(material);
+        setHologramLine(page, lineIndex, new ItemStack(material));
+    }
+    
+    /**
+     * Set an ItemStack as new content to hologram line and update it.
+     *
+     * @param page The parent page.
+     * @param lineIndex The index of the line.
+     * @param item ItemStack for new content.
+     * @throws IllegalArgumentException If any of the arguments are null or the indexes are invalid.
+     */
+    public static void setHologramLine(HologramPage page, int lineIndex, ItemStack item) throws IllegalArgumentException {
+        Validate.notNull(item);
+        setHologramLine(page, lineIndex, "#ICON:" + HologramItem.fromItemStack(item).getContent());
+    }
 
     /**
      * Set a new content to hologram line and update it.
@@ -454,7 +642,33 @@ public final class DHAPI {
         }
         setHologramLine(line, content);
     }
-
+    
+    /**
+     * Set a Material as new content to hologram line and update it.
+     *
+     * @param hologram The parent hologram.
+     * @param lineIndex The index of the line.
+     * @param material Material for new content.
+     * @throws IllegalArgumentException If any of the arguments is null or the indexes are invalid.
+     */
+    public static void setHologramLine(Hologram hologram, int lineIndex, Material material) throws IllegalArgumentException {
+        Validate.notNull(material);
+        setHologramLine(hologram, lineIndex, new ItemStack(material));
+    }
+    
+    /**
+     * Set a ItemStack as new content to hologram line and update it.
+     *
+     * @param hologram The parent hologram.
+     * @param lineIndex The index of the line.
+     * @param item ItemStack for new content.
+     * @throws IllegalArgumentException If any of the arguments is null or the indexes are invalid.
+     */
+    public static void setHologramLine(Hologram hologram, int lineIndex, ItemStack item) throws IllegalArgumentException {
+        Validate.notNull(item);
+        setHologramLine(hologram, lineIndex, "#ICON:" + HologramItem.fromItemStack(item).getContent());
+    }
+    
     /**
      * Set a new content to hologram line and update it.
      *
@@ -466,7 +680,35 @@ public final class DHAPI {
     public static void setHologramLine(Hologram hologram, int lineIndex, String content) throws IllegalArgumentException {
         setHologramLine(hologram, 0, lineIndex, content);
     }
-
+    
+    /**
+     * Set a Material as new content to hologram line and update it.
+     *
+     * @param hologram The parent hologram.
+     * @param pageIndex The index of the parent page.
+     * @param lineIndex The index of the line.
+     * @param material Material for new content.
+     * @throws IllegalArgumentException If any of the arguments is null or the indexes are invalid.
+     */
+    public static void setHologramLine(Hologram hologram, int pageIndex, int lineIndex, Material material) throws IllegalArgumentException {
+        Validate.notNull(material);
+        setHologramLine(hologram, pageIndex, lineIndex, new ItemStack(material));
+    }
+    
+    /**
+     * Set a ItemStack as new content to hologram line and update it.
+     *
+     * @param hologram The parent hologram.
+     * @param pageIndex The index of the parent page.
+     * @param lineIndex The index of the line.
+     * @param item ItemStack for new content.
+     * @throws IllegalArgumentException If any of the arguments is null or the indexes are invalid.
+     */
+    public static void setHologramLine(Hologram hologram, int pageIndex, int lineIndex, ItemStack item) throws IllegalArgumentException {
+        Validate.notNull(item);
+        setHologramLine(hologram, pageIndex, lineIndex, "#ICON:" + HologramItem.fromItemStack(item).getContent());
+    }
+    
     /**
      * Set a new content to hologram line and update it.
      *

--- a/src/main/java/eu/decentsoftware/holograms/api/utils/items/HologramItem.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/utils/items/HologramItem.java
@@ -128,9 +128,8 @@ public class HologramItem {
 		stringBuilder.append(" ");
 		Map<Enchantment, Integer> enchants = itemStack.getEnchantments();
 		if (enchants != null && !enchants.isEmpty()) {
-			stringBuilder.append("!ENCHANTED");
+			stringBuilder.append("!ENCHANTED").append(" ");
 		}
-		stringBuilder.append(" ");
 		if (material.name().contains("HEAD") || material.name().contains("SKULL")) {
 			String owner = itemBuilder.getSkullOwner();
 			String texture = itemBuilder.getSkullTexture();


### PR DESCRIPTION
This PR (finally!) adds overloads for all the `add`, `set` and `insert` methods of the `DHAPI` to allow the direct usage of ItemStacks and Materials as lines.

Before you had to do a workaround with `"#ICON:" + HologramItem.fromItemStack(ItemStack).getContent()` to achieve the same result.
The new methods basically do this for you now.

I was considering to also add a `setLines` option for ItemStack and Material by having a more generic method accepting `List<Object>` as argument and then have some `instanceof` checks for it, but I decided against it because of conflicts due to the new method having the same erasure as the already existing one...
I could change the existing one a bit to use Object lists, but not sure if that wouldn't be a breaking change for end users...

Either way, I hope all the people that asked for how to add items using the API can now use this...

And before you ask: No I won't add overloads for entities (yet). Can't be bothered to waste even more time...