### PR TITLE
Improve tab completion for Line Sub commands

### DIFF
--- a/src/main/java/eu/decentsoftware/holograms/api/commands/DecentCommand.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/commands/DecentCommand.java
@@ -9,10 +9,8 @@ import eu.decentsoftware.holograms.api.utils.Common;
 import org.apache.commons.lang.Validate;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
-import org.bukkit.util.StringUtil;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 public abstract class DecentCommand extends Command implements CommandBase {
 
@@ -135,16 +133,14 @@ public abstract class DecentCommand extends Command implements CommandBase {
 		}
 
 		if (args.length == 1) {
-			List<String> matches = Lists.newLinkedList();
-			List<String> subs = getSubCommands().stream()
-					.map(CommandBase::getName)
-					.collect(Collectors.toList());
-			getSubCommands().forEach(sub ->
-					subs.addAll(Lists.newArrayList(sub.getAliases()))
-			);
-
-			StringUtil.copyPartialMatches(args[0], subs, matches);
-
+			List<String> subs = new ArrayList<>();
+			getSubCommands().forEach(cmd -> {
+				subs.add(cmd.getName());
+				subs.addAll(Lists.newArrayList(cmd.getAliases()));
+			});
+			
+			List<String> matches = TabCompleteHandler.getPartialMatches(args[0], subs);
+			
 			if (!matches.isEmpty()) {
 				Collections.sort(matches);
 				return matches;

--- a/src/main/java/eu/decentsoftware/holograms/api/commands/TabCompleteHandler.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/commands/TabCompleteHandler.java
@@ -8,10 +8,8 @@ import eu.decentsoftware.holograms.api.actions.ClickType;
 import eu.decentsoftware.holograms.api.holograms.Hologram;
 import eu.decentsoftware.holograms.api.holograms.HologramPage;
 import org.bukkit.command.CommandSender;
-import org.bukkit.util.StringUtil;
 
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -22,81 +20,84 @@ public interface TabCompleteHandler {
 
 	TabCompleteHandler HOLOGRAM_NAMES = (sender, args) -> {
 		if (args.length == 1) {
-			List<String> matches = Lists.newArrayList();
-			StringUtil.copyPartialMatches(args[0], PLUGIN.getHologramManager().getHologramNames(), matches);
-			return matches;
+			return getPartialMatches(args[0], PLUGIN.getHologramManager().getHologramNames());
 		}
 		return null;
 	};
 
 	TabCompleteHandler HOLOGRAM_PAGES = (sender, args) -> {
-		List<String> matches = Lists.newArrayList();
 		if (args.length == 1) {
-			StringUtil.copyPartialMatches(args[0], PLUGIN.getHologramManager().getHologramNames(), matches);
+			return getPartialMatches(args[0], PLUGIN.getHologramManager().getHologramNames());
 		} else if (args.length == 2) {
 			Hologram hologram = PLUGIN.getHologramManager().getHologram(args[0]);
 			if (hologram != null) {
-				StringUtil.copyPartialMatches(args[1], IntStream
-						.rangeClosed(1, hologram.size())
-						.boxed().map(String::valueOf)
-						.collect(Collectors.toList()), matches);
+				return getPartialMatches(args[1], IntStream
+					.rangeClosed(1, hologram.size())
+					.boxed().map(String::valueOf)
+					.collect(Collectors.toList()));
 			}
 		}
-		return matches;
+		return null;
 	};
 
 	TabCompleteHandler HOLOGRAM_PAGES_CLICK_TYPES = (sender, args) -> {
-		List<String> matches = Lists.newArrayList();
 		if (args.length == 1) {
-			StringUtil.copyPartialMatches(args[0], PLUGIN.getHologramManager().getHologramNames(), matches);
+			return getPartialMatches(args[0], PLUGIN.getHologramManager().getHologramNames());
 		} else if (args.length == 2) {
 			Hologram hologram = PLUGIN.getHologramManager().getHologram(args[0]);
 			if (hologram != null) {
-				StringUtil.copyPartialMatches(args[1], IntStream
-						.rangeClosed(1, hologram.size())
-						.boxed().map(String::valueOf)
-						.collect(Collectors.toList()), matches);
+				return getPartialMatches(args[1], IntStream
+					.rangeClosed(1, hologram.size())
+					.boxed().map(String::valueOf)
+					.collect(Collectors.toList()));
 			}
 		} else if (args.length == 3) {
-			StringUtil.copyPartialMatches(args[2], Arrays.stream(ClickType.values()).map(Enum::name).collect(Collectors.toList()), matches);
+			return getPartialMatches(args[2], Arrays.stream(ClickType.values())
+				.map(ClickType::name)
+				.collect(Collectors.toList()));
 		}
-		return matches;
+		return null;
 	};
 
 	TabCompleteHandler HOLOGRAM_PAGES_ACTIONS = (sender, args) -> {
-		List<String> matches = Lists.newArrayList();
 		if (args.length == 1) {
-			StringUtil.copyPartialMatches(args[0], PLUGIN.getHologramManager().getHologramNames(), matches);
+			return getPartialMatches(args[0], PLUGIN.getHologramManager().getHologramNames());
 		} else if (args.length == 2) {
 			Hologram hologram = PLUGIN.getHologramManager().getHologram(args[0]);
 			if (hologram != null) {
-				StringUtil.copyPartialMatches(args[1], IntStream
-						.rangeClosed(1, hologram.size())
-						.boxed().map(String::valueOf)
-						.collect(Collectors.toList()), matches);
+				return getPartialMatches(args[1], IntStream
+					.rangeClosed(1, hologram.size())
+					.boxed().map(String::valueOf)
+					.collect(Collectors.toList()));
 			}
 		} else if (args.length == 3) {
-			StringUtil.copyPartialMatches(args[2], Arrays.stream(ClickType.values()).map(ClickType::name).collect(Collectors.toList()), matches);
+			return getPartialMatches(args[2], Arrays.stream(ClickType.values())
+				.map(ClickType::name)
+				.collect(Collectors.toList()));
 		} else if (args.length == 4) {
-			StringUtil.copyPartialMatches(args[3], ActionType.getActionTypes().stream().map(ActionType::getName).collect(Collectors.toList()), matches);
+			return getPartialMatches(args[2], ActionType.getActionTypes().stream()
+				.map(ActionType::getName)
+				.collect(Collectors.toList()));
 		}
-		return matches;
+		return null;
 	};
 
 	TabCompleteHandler HOLOGRAM_PAGES_ACTION_INDEXES = (sender, args) -> {
 		List<String> matches = Lists.newArrayList();
 		if (args.length == 1) {
-			StringUtil.copyPartialMatches(args[0], PLUGIN.getHologramManager().getHologramNames(), matches);
+			return getPartialMatches(args[0], PLUGIN.getHologramManager().getHologramNames());
 		} else if (args.length == 2) {
 			Hologram hologram = PLUGIN.getHologramManager().getHologram(args[0]);
 			if (hologram != null) {
-				StringUtil.copyPartialMatches(args[1], IntStream
-						.rangeClosed(1, hologram.size())
-						.boxed().map(String::valueOf)
-						.collect(Collectors.toList()), matches);
+				return getPartialMatches(args[1], IntStream
+					.rangeClosed(1, hologram.size())
+					.boxed().map(String::valueOf)
+					.collect(Collectors.toList()));
 			}
 		} else if (args.length == 3) {
-			StringUtil.copyPartialMatches(args[2], Arrays.stream(ClickType.values()).map(ClickType::name).collect(Collectors.toList()), matches);
+			return getPartialMatches(args[2], Arrays.stream(ClickType.values())
+				.map(ClickType::name)
+				.collect(Collectors.toList()));
 		} else if (args.length == 4) {
 			Hologram hologram = PLUGIN.getHologramManager().getHologram(args[0]);
 			if (hologram != null) {
@@ -104,16 +105,39 @@ public interface TabCompleteHandler {
 				if (page != null) {
 					ClickType clickType = ClickType.fromString(args[2]);
 					if (clickType != null) {
-						StringUtil.copyPartialMatches(args[3], IntStream
-								.rangeClosed(1, page.getActions(clickType).size())
-								.boxed().map(String::valueOf)
-								.collect(Collectors.toList()), matches);
+						return getPartialMatches(args[3], IntStream
+							.rangeClosed(1, page.getActions(clickType).size())
+							.boxed().map(String::valueOf)
+							.collect(Collectors.toList()));
 					}
 				}
 			}
 		}
 		return matches;
 	};
+	
+	static List<String> getPartialMatches(String token, String... originals) {
+		return getPartialMatches(token, Arrays.asList(originals));
+	}
+	
+	static List<String> getPartialMatches(String token, Collection<String> originals) {
+		if (originals == null) {
+			return Collections.emptyList();
+		}
+		
+		if (token == null || token.isEmpty()) {
+			return new ArrayList<>(originals);
+		}
+		
+		List<String> matches = new ArrayList<>();
+		for (String str : originals) {
+			if (str.length() >= token.length() && str.regionMatches(true, 0, token, 0, token.length())) {
+				matches.add(str);
+			}
+		}
+		
+		return matches;
+	}
 
 	/**
 	 * Handle Tab Complete.

--- a/src/main/java/eu/decentsoftware/holograms/api/utils/entity/DecentEntityType.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/utils/entity/DecentEntityType.java
@@ -12,13 +12,11 @@ public class DecentEntityType {
 
     private static final Map<String, EntityType> ENTITY_TYPE_ALIASES = new HashMap<>();
     private static final Set<String> ENTITY_TYPE_BLACKLIST;
-    private static final EnumSet<EntityType> ENTITY_TYPES = EnumSet.allOf(EntityType.class);
+    private static final Set<EntityType> ENTITY_TYPES;
 
     static {
-        for (EntityType entityType : ENTITY_TYPES) {
-            ENTITY_TYPE_ALIASES.put(Common.removeSpacingChars(entityType.name()).toLowerCase(), entityType);
-        }
-
+        ENTITY_TYPES = new HashSet<>(EnumSet.allOf(EntityType.class));
+        
         ENTITY_TYPE_BLACKLIST = Sets.newHashSet(
                 "ARMOR_STAND",
                 "PRIMED_TNT",
@@ -52,17 +50,20 @@ public class DecentEntityType {
                 "TIPPED_ARROW",
                 "UNKNOWN"
         );
+        
+        ENTITY_TYPES.removeIf(entityType -> ENTITY_TYPE_BLACKLIST.contains(entityType.name()));
+    
+        for (EntityType entityType : ENTITY_TYPES) {
+            ENTITY_TYPE_ALIASES.put(Common.removeSpacingChars(entityType.name()).toLowerCase(), entityType);
+        }
     }
 
     public static List<EntityType> getAllowedEntityTypes() {
-        return ENTITY_TYPES.stream()
-            .filter(DecentEntityType::isAllowed)
-            .collect(Collectors.toList());
+        return new ArrayList<>(ENTITY_TYPES);
     }
 
     public static List<String> getAllowedEntityTypeNames() {
         return ENTITY_TYPES.stream()
-            .filter(DecentEntityType::isAllowed)
             .map(EntityType::name)
             .collect(Collectors.toList());
     }
@@ -75,9 +76,8 @@ public class DecentEntityType {
     public static EntityType parseEntityType(String string) {
         EntityType entityType = ENTITY_TYPE_ALIASES.get(Common.removeSpacingChars(string).toLowerCase());
         if (entityType == null) return null;
-        if (isAllowed(entityType)) {
-            return null;
-        }
+        if (isAllowed(entityType)) return null;
+        
         return entityType;
     }
 

--- a/src/main/java/eu/decentsoftware/holograms/api/utils/entity/DecentEntityType.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/utils/entity/DecentEntityType.java
@@ -12,9 +12,10 @@ public class DecentEntityType {
 
     private static final Map<String, EntityType> ENTITY_TYPE_ALIASES = new HashMap<>();
     private static final Set<String> ENTITY_TYPE_BLACKLIST;
+    private static final EnumSet<EntityType> ENTITY_TYPES = EnumSet.allOf(EntityType.class);
 
     static {
-        for (EntityType entityType : EntityType.values()) {
+        for (EntityType entityType : ENTITY_TYPES) {
             ENTITY_TYPE_ALIASES.put(Common.removeSpacingChars(entityType.name()).toLowerCase(), entityType);
         }
 
@@ -54,16 +55,16 @@ public class DecentEntityType {
     }
 
     public static List<EntityType> getAllowedEntityTypes() {
-        return Arrays.stream(EntityType.values())
-                .filter(entityType -> !ENTITY_TYPE_BLACKLIST.contains(entityType.name()))
-                .collect(Collectors.toList());
+        return ENTITY_TYPES.stream()
+            .filter(DecentEntityType::isAllowed)
+            .collect(Collectors.toList());
     }
 
     public static List<String> getAllowedEntityTypeNames() {
-        return Arrays.stream(EntityType.values())
-                .map(EntityType::name)
-                .filter(name -> !ENTITY_TYPE_BLACKLIST.contains(name))
-                .collect(Collectors.toList());
+        return ENTITY_TYPES.stream()
+            .filter(DecentEntityType::isAllowed)
+            .map(EntityType::name)
+            .collect(Collectors.toList());
     }
 
     public static boolean isAllowed(EntityType entityType) {
@@ -74,7 +75,7 @@ public class DecentEntityType {
     public static EntityType parseEntityType(String string) {
         EntityType entityType = ENTITY_TYPE_ALIASES.get(Common.removeSpacingChars(string).toLowerCase());
         if (entityType == null) return null;
-        if (ENTITY_TYPE_BLACKLIST.contains(entityType.name())) {
+        if (isAllowed(entityType)) {
             return null;
         }
         return entityType;

--- a/src/main/java/eu/decentsoftware/holograms/api/utils/items/HologramItem.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/utils/items/HologramItem.java
@@ -41,8 +41,8 @@ public class HologramItem {
 		if (enchanted) itemBuilder.withUnsafeEnchantment(Enchantment.DURABILITY, 0);
 		if (material.name().contains("SKULL") || material.name().contains("HEAD")) {
 			if (extras != null) {
-				String extrasFinal = player == null ? extras : PAPI.setPlaceholders(player, extras);
-				if (!extrasFinal.trim().isEmpty()) {
+				String extrasFinal = player == null ? extras.trim() : PAPI.setPlaceholders(player, extras).trim();
+				if (!extrasFinal.isEmpty()) {
 					if (extrasFinal.startsWith("HEADDATABASE_") && Bukkit.getPluginManager().isPluginEnabled("HeadDatabase")) {
 						String headDatabaseId = extrasFinal.substring("HEADDATABASE_".length());
 						itemBuilder.withItemStack(HeadDatabaseUtils.getHeadItemStackById(headDatabaseId));

--- a/src/main/java/eu/decentsoftware/holograms/plugin/commands/FeatureSubCommand.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/commands/FeatureSubCommand.java
@@ -5,7 +5,6 @@ import eu.decentsoftware.holograms.api.Lang;
 import eu.decentsoftware.holograms.api.commands.*;
 import eu.decentsoftware.holograms.api.features.AbstractFeature;
 import eu.decentsoftware.holograms.api.utils.Common;
-import org.bukkit.util.StringUtil;
 
 import java.util.List;
 
@@ -85,9 +84,7 @@ public class FeatureSubCommand extends DecentCommand {
         public TabCompleteHandler getTabCompleteHandler() {
             return (sender, args) -> {
                 if (args.length == 1) {
-                    List<String> matches = Lists.newArrayList();
-                    StringUtil.copyPartialMatches(args[0], PLUGIN.getFeatureManager().getFeatureNames(), matches);
-                    return matches;
+                    return TabCompleteHandler.getPartialMatches(args[0], PLUGIN.getFeatureManager().getFeatureNames());
                 }
                 return null;
             };
@@ -130,9 +127,7 @@ public class FeatureSubCommand extends DecentCommand {
         public TabCompleteHandler getTabCompleteHandler() {
             return (sender, args) -> {
                 if (args.length == 1) {
-                    List<String> matches = Lists.newArrayList();
-                    StringUtil.copyPartialMatches(args[0], PLUGIN.getFeatureManager().getFeatureNames(), matches);
-                    return matches;
+                    return TabCompleteHandler.getPartialMatches(args[0], PLUGIN.getFeatureManager().getFeatureNames());
                 }
                 return null;
             };
@@ -219,9 +214,7 @@ public class FeatureSubCommand extends DecentCommand {
         public TabCompleteHandler getTabCompleteHandler() {
             return (sender, args) -> {
                 if (args.length == 1) {
-                    List<String> matches = Lists.newArrayList();
-                    StringUtil.copyPartialMatches(args[0], PLUGIN.getFeatureManager().getFeatureNames(), matches);
-                    return matches;
+                    return TabCompleteHandler.getPartialMatches(args[0], PLUGIN.getFeatureManager().getFeatureNames());
                 }
                 return null;
             };
@@ -297,9 +290,7 @@ public class FeatureSubCommand extends DecentCommand {
         public TabCompleteHandler getTabCompleteHandler() {
             return (sender, args) -> {
                 if (args.length == 1) {
-                    List<String> matches = Lists.newArrayList();
-                    StringUtil.copyPartialMatches(args[0], PLUGIN.getFeatureManager().getFeatureNames(), matches);
-                    return matches;
+                    return TabCompleteHandler.getPartialMatches(args[0], PLUGIN.getFeatureManager().getFeatureNames());
                 }
                 return null;
             };

--- a/src/main/java/eu/decentsoftware/holograms/plugin/commands/HologramSubCommand.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/commands/HologramSubCommand.java
@@ -15,7 +15,6 @@ import eu.decentsoftware.holograms.plugin.Validator;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
-import org.bukkit.util.StringUtil;
 
 import java.util.Arrays;
 import java.util.List;
@@ -170,13 +169,12 @@ public class HologramSubCommand extends DecentCommand {
 		@Override
 		public TabCompleteHandler getTabCompleteHandler() {
 			return (sender, args) -> {
-				List<String> matches = Lists.newArrayList();
 				if (args.length == 1 || args.length == 3) {
-					StringUtil.copyPartialMatches(args[0], PLUGIN.getHologramManager().getHologramNames(), matches);
+					return TabCompleteHandler.getPartialMatches(args[0], PLUGIN.getHologramManager().getHologramNames());
 				} else if (args.length == 2) {
-					StringUtil.copyPartialMatches(args[1], Lists.newArrayList("X", "Y", "Z", "XZ", "FACE", "FACING"), matches);
+					return TabCompleteHandler.getPartialMatches(args[1], "X", "Y", "Z", "XZ", "FACE", "FACING");
 				}
-				return matches;
+				return null;
 			};
 		}
 
@@ -305,20 +303,15 @@ public class HologramSubCommand extends DecentCommand {
 		@Override
 		public TabCompleteHandler getTabCompleteHandler() {
 			return (sender, args) -> {
-				List<String> matches = Lists.newArrayList();
 				if (args.length == 3 && (args[1].startsWith("#ICON:") || args[1].startsWith("#HEAD:") || args[1].startsWith("#SMALLHEAD:"))) {
-					StringUtil.copyPartialMatches(
-							args[2],
-							Arrays.stream(Material.values())
-									.filter(DecentMaterial::isItem)
-									.map(Material::name)
-									.collect(Collectors.toList()),
-							matches
-					);
+					return TabCompleteHandler.getPartialMatches(args[2], Arrays.stream(Material.values())
+						.filter(DecentMaterial::isItem)
+						.map(Material::name)
+						.collect(Collectors.toList()));
 				} else if (args.length == 3 && args[1].startsWith("#ENTITY:")) {
-					StringUtil.copyPartialMatches(args[2], DecentEntityType.getAllowedEntityTypeNames(), matches);
+					return TabCompleteHandler.getPartialMatches(args[2], DecentEntityType.getAllowedEntityTypeNames());
 				}
-				return matches;
+				return null;
 			};
 		}
 
@@ -454,13 +447,12 @@ public class HologramSubCommand extends DecentCommand {
 		@Override
 		public TabCompleteHandler getTabCompleteHandler() {
 			return (sender, args) -> {
-				List<String> matches = Lists.newArrayList();
 				if (args.length == 1 || args.length == 3) {
-					StringUtil.copyPartialMatches(args[0], PLUGIN.getHologramManager().getHologramNames(), matches);
+					return TabCompleteHandler.getPartialMatches(args[0], PLUGIN.getHologramManager().getHologramNames());
 				} else if (args.length == 2) {
-					StringUtil.copyPartialMatches(args[1], Lists.newArrayList("true", "false"), matches);
+					return TabCompleteHandler.getPartialMatches(args[1], "true", "false");
 				}
-				return matches;
+				return null;
 			};
 		}
 
@@ -495,13 +487,12 @@ public class HologramSubCommand extends DecentCommand {
 		@Override
 		public TabCompleteHandler getTabCompleteHandler() {
 			return (sender, args) -> {
-				List<String> matches = Lists.newArrayList();
 				if (args.length == 1) {
-					StringUtil.copyPartialMatches(args[0], PLUGIN.getHologramManager().getHologramNames(), matches);
+					return TabCompleteHandler.getPartialMatches(args[0], PLUGIN.getHologramManager().getHologramNames());
 				} else if (args.length == 2) {
-					StringUtil.copyPartialMatches(args[1], Lists.newArrayList("true", "false"), matches);
+					return TabCompleteHandler.getPartialMatches(args[1], "true", "false");
 				}
-				return matches;
+				return null;
 			};
 		}
 
@@ -581,15 +572,12 @@ public class HologramSubCommand extends DecentCommand {
 		@Override
 		public TabCompleteHandler getTabCompleteHandler() {
 			return (sender, args) -> {
-				List<String> matches = Lists.newArrayList();
 				if (args.length == 1 || args.length == 3) {
-					StringUtil.copyPartialMatches(args[0], PLUGIN.getHologramManager().getHologramNames(), matches);
+					return TabCompleteHandler.getPartialMatches(args[0], PLUGIN.getHologramManager().getHologramNames());
 				} else if (args.length == 2) {
-					StringUtil.copyPartialMatches(args[1], Lists.newArrayList(
-							"SOUTH", "WEST", "NORTH", "EAST", "0", "45", "90", "135", "180", "-45", "-90", "-135"
-					), matches);
+					return TabCompleteHandler.getPartialMatches(args[1], "NORTH", "EAST", "SOUTH", "WEST", "0", "45", "90", "135", "180", "-45", "-90", "-135");
 				}
-				return matches;
+				return null;
 			};
 		}
 
@@ -623,17 +611,14 @@ public class HologramSubCommand extends DecentCommand {
 		@Override
 		public TabCompleteHandler getTabCompleteHandler() {
 			return (sender, args) -> {
-				List<String> matches = Lists.newArrayList();
 				if (args.length == 1) {
-					StringUtil.copyPartialMatches(args[0], PLUGIN.getHologramManager().getHologramNames(), matches);
+					return TabCompleteHandler.getPartialMatches(args[0], PLUGIN.getHologramManager().getHologramNames());
 				} else if (args.length == 2) {
-					StringUtil.copyPartialMatches(args[1],
-							Arrays.stream(EnumFlag.values())
-									.map(EnumFlag::name)
-									.collect(Collectors.toList()), matches
-					);
+					return TabCompleteHandler.getPartialMatches(args[1], Arrays.stream(EnumFlag.values())
+						.map(EnumFlag::name)
+						.collect(Collectors.toList()));
 				}
-				return matches;
+				return null;
 			};
 		}
 
@@ -668,17 +653,14 @@ public class HologramSubCommand extends DecentCommand {
 		@Override
 		public TabCompleteHandler getTabCompleteHandler() {
 			return (sender, args) -> {
-				List<String> matches = Lists.newArrayList();
 				if (args.length == 1) {
-					StringUtil.copyPartialMatches(args[0], PLUGIN.getHologramManager().getHologramNames(), matches);
+					return TabCompleteHandler.getPartialMatches(args[0], PLUGIN.getHologramManager().getHologramNames());
 				} else if (args.length == 2) {
-					StringUtil.copyPartialMatches(args[1],
-							Arrays.stream(EnumFlag.values())
-									.map(EnumFlag::name)
-									.collect(Collectors.toList()), matches
-					);
+					return TabCompleteHandler.getPartialMatches(args[1], Arrays.stream(EnumFlag.values())
+						.map(EnumFlag::name)
+						.collect(Collectors.toList()));
 				}
-				return matches;
+				return null;
 			};
 		}
 
@@ -916,9 +898,7 @@ public class HologramSubCommand extends DecentCommand {
 				Hologram hologram;
 				Location location;
 				if (args.length == 1) {
-					List<String> matches = Lists.newArrayList();
-					StringUtil.copyPartialMatches(args[0], PLUGIN.getHologramManager().getHologramNames(), matches);
-					return matches;
+					return TabCompleteHandler.getPartialMatches(args[0], PLUGIN.getHologramManager().getHologramNames());
 				} else if (args.length == 2 && Validator.isPlayer(sender)) {
 					hologram = PLUGIN.getHologramManager().getHologram(args[0]);
 					location = hologram == null ? null : hologram.getLocation();

--- a/src/main/java/eu/decentsoftware/holograms/plugin/commands/HologramsCommand.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/commands/HologramsCommand.java
@@ -13,7 +13,6 @@ import eu.decentsoftware.holograms.plugin.convertors.GHoloConverter;
 import eu.decentsoftware.holograms.plugin.convertors.HolographicDisplaysConvertor;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
-import org.bukkit.util.StringUtil;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -189,7 +188,7 @@ public class HologramsCommand extends DecentCommand {
                 List<String> header = Lists.newArrayList("", " &3&lHOLOGRAM LIST - #" + (currentPage + 1), " &fList of all existing holograms.", "");
                 Function<Hologram, String> parseItem = hologram -> {
                     Location l = hologram.getLocation();
-                    String name = hologram.isEnabled() ? hologram.getName() : "&c" + hologram.getName();
+                    String name = (hologram.isEnabled() ? "" : "&c") + hologram.getName();
                     return String.format(" &8• &b%s &8| &7%s, %.2f, %.2f, %.2f", name, l.getWorld().getName(), l.getX(), l.getY(), l.getZ());
                 };
                 Message.sendPaginatedMessage((Player) sender, currentPage, "/dh list %d", 15, header, null, holograms, parseItem);
@@ -199,7 +198,26 @@ public class HologramsCommand extends DecentCommand {
 
         @Override
         public TabCompleteHandler getTabCompleteHandler() {
-            return null;
+            return (sender, args) -> {
+                if (args.length != 1) {
+                    return null;
+                }
+    
+                int holograms = PLUGIN.getHologramManager().getHolograms().size();
+                if (holograms == 0) {
+                    return null;
+                }
+    
+                List<String> pages = new ArrayList<>();
+                int page = 0;
+                while(holograms > 0) {
+                    page++;
+                    pages.add(String.valueOf(page));
+                    holograms -= 15;
+                }
+    
+                return TabCompleteHandler.getPartialMatches(args[0], pages);
+            };
         }
 
     }
@@ -312,9 +330,9 @@ public class HologramsCommand extends DecentCommand {
         public TabCompleteHandler getTabCompleteHandler() {
             return (sender, args) -> {
                 if (args.length == 1) {
-                    return StringUtil.copyPartialMatches(args[0], Arrays.stream(ConvertorType.values()).map(ConvertorType::getName).collect(Collectors.toList()), Lists.newArrayList());
+                    return TabCompleteHandler.getPartialMatches(args[0], Arrays.stream(ConvertorType.values()).map(ConvertorType::getName).collect(Collectors.toList()));
                 }
-                return new ArrayList<>();
+                return null;
             };
         }
 

--- a/src/main/java/eu/decentsoftware/holograms/plugin/commands/LineSubCommand.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/commands/LineSubCommand.java
@@ -17,7 +17,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
-import org.bukkit.util.StringUtil;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -30,7 +29,12 @@ import java.util.stream.IntStream;
 		aliases = {"line", "l"}
 )
 public class LineSubCommand extends DecentCommand {
-
+	
+	private static final List<String> items = Arrays.stream(Material.values())
+		.filter(DecentMaterial::isItem)
+		.map(Material::name)
+		.collect(Collectors.toList());
+	
 	public LineSubCommand() {
 		super("lines");
 
@@ -108,15 +112,11 @@ public class LineSubCommand extends DecentCommand {
 		@Override
 		public TabCompleteHandler getTabCompleteHandler() {
 			return (sender, args) -> {
-				List<String> matches = new ArrayList<>();
-				if (args.length == 1) {
-					putHologramNames(args[0], matches);
-				} else if (args.length == 2) {
-					putPages(args[0], args[1], matches);
-				} else if (args.length >= 3) {
-					putContent(Arrays.copyOfRange(args, 2, args.length), matches);
+				if (args.length <= 2) {
+					return handleCommonArgs(args);
+				} else {
+					return getContent(Arrays.copyOfRange(args, 2, args.length));
 				}
-				return matches;
 			};
 		}
 	}
@@ -173,19 +173,15 @@ public class LineSubCommand extends DecentCommand {
 		@Override
 		public TabCompleteHandler getTabCompleteHandler() {
 			return (sender, args) -> {
-				List<String> matches = new ArrayList<>();
-				if (args.length == 1) {
-					putHologramNames(args[0], matches);
-				} else if (args.length == 2) {
-					putPages(args[0], args[1], matches);
-				} else if (args.length == 3) {
-					putLines(args[0], Validator.getInteger(args[1]), args[2], matches);
+				if (args.length <= 3) {
+					return handleCommonArgs(args);
 				} else if (args.length == 4) {
-					putLines(args[0], Validator.getInteger(args[1]), args[3], matches);
+					return getLines(args[0], Validator.getInteger(args[1]), args[3]);
 				} else if (args.length == 5) {
-					StringUtil.copyPartialMatches(args[2], Arrays.asList("X", "Z", "XZ"), matches);
+					return getPartialMatches(args[4], Arrays.asList("X", "Z", "XZ"));
 				}
-				return matches;
+				
+				return Collections.emptyList();
 			};
 		}
 
@@ -224,17 +220,7 @@ public class LineSubCommand extends DecentCommand {
 
 		@Override
 		public TabCompleteHandler getTabCompleteHandler() {
-			return (sender, args) -> {
-				List<String> matches = new ArrayList<>();
-				if (args.length == 1) {
-					putHologramNames(args[0], matches);
-				} else if (args.length == 2) {
-					putPages(args[0], args[1], matches);
-				} else if (args.length == 3) {
-					putLines(args[0], Validator.getInteger(args[1]), args[2], matches);
-				}
-				return matches;
-			};
+			return (sender, args) -> handleCommonArgs(args);
 		}
 
 	}
@@ -273,17 +259,11 @@ public class LineSubCommand extends DecentCommand {
 		@Override
 		public TabCompleteHandler getTabCompleteHandler() {
 			return (sender, args) -> {
-				List<String> matches = new ArrayList<>();
-				if (args.length == 1) {
-					putHologramNames(args[0], matches);
-				} else if (args.length == 2) {
-					putPages(args[0], args[1], matches);
-				} else if (args.length == 3) {
-					putLines(args[0], Validator.getInteger(args[1]), args[2], matches);
-				} else if (args.length == 4) {
-					putFlags(args[3], matches);
+				if (args.length <= 3) {
+					return handleCommonArgs(args);
+				} else {
+					return getFlags(args[3]);
 				}
-				return matches;
 			};
 		}
 
@@ -323,17 +303,11 @@ public class LineSubCommand extends DecentCommand {
 		@Override
 		public TabCompleteHandler getTabCompleteHandler() {
 			return (sender, args) -> {
-				List<String> matches = new ArrayList<>();
-				if (args.length == 1) {
-					putHologramNames(args[0], matches);
-				} else if (args.length == 2) {
-					putPages(args[0], args[1], matches);
-				} else if (args.length == 3) {
-					putLines(args[0], Validator.getInteger(args[1]), args[2], matches);
-				} else if (args.length == 4) {
-					putFlags(args[3], matches);
+				if (args.length <= 3) {
+					return handleCommonArgs(args);
+				} else {
+					return getFlags(args[3]);
 				}
-				return matches;
 			};
 		}
 
@@ -376,15 +350,11 @@ public class LineSubCommand extends DecentCommand {
 		@Override
 		public TabCompleteHandler getTabCompleteHandler() {
 			return (sender, args) -> {
-				List<String> matches = new ArrayList<>();
-				if (args.length == 1) {
-					putHologramNames(args[0], matches);
-				} else if (args.length == 2) {
-					putPages(args[0], args[1], matches);
-				} else if (args.length == 3) {
-					putLines(args[0], Validator.getInteger(args[1]), args[2], matches);
+				if (args.length <= 3) {
+					return handleCommonArgs(args);
 				}
-				return matches;
+				
+				return Collections.emptyList();
 			};
 		}
 
@@ -475,17 +445,7 @@ public class LineSubCommand extends DecentCommand {
 
 		@Override
 		public TabCompleteHandler getTabCompleteHandler() {
-			return (sender, args) -> {
-				List<String> matches = new ArrayList<>();
-				if (args.length == 1) {
-					putHologramNames(args[0], matches);
-				} else if (args.length == 2) {
-					putPages(args[0], args[1], matches);
-				} else if (args.length == 3) {
-					putLines(args[0], Validator.getInteger(args[1]), args[2], matches);
-				}
-				return matches;
-			};
+			return (sender, args) -> handleCommonArgs(args);
 		}
 
 	}
@@ -525,17 +485,11 @@ public class LineSubCommand extends DecentCommand {
 		@Override
 		public TabCompleteHandler getTabCompleteHandler() {
 			return (sender, args) -> {
-				List<String> matches = Lists.newArrayList();
-				if (args.length == 1) {
-					putHologramNames(args[0], matches);
-				} else if (args.length == 2) {
-					putPages(args[0], args[1], matches);
-				} else if (args.length == 3) {
-					putLines(args[0], Validator.getInteger(args[1]), args[2], matches);
-				} else if (args.length >= 4) {
-					putContent(Arrays.copyOfRange(args, 3, args.length), matches);
+				if (args.length <= 3) {
+					return handleCommonArgs(args);
+				} else {
+					return getContent(Arrays.copyOfRange(args, 3, args.length));
 				}
-				return matches;
 			};
 		}
 
@@ -576,17 +530,7 @@ public class LineSubCommand extends DecentCommand {
 
 		@Override
 		public TabCompleteHandler getTabCompleteHandler() {
-			return (sender, args) -> {
-				List<String> matches = new ArrayList<>();
-				if (args.length == 1) {
-					putHologramNames(args[0], matches);
-				} else if (args.length == 2) {
-					putPages(args[0], args[1], matches);
-				} else if (args.length == 3) {
-					putLines(args[0], Validator.getInteger(args[1]), args[2], matches);
-				}
-				return matches;
-			};
+			return (sender, args) -> handleCommonArgs(args);
 		}
 
 	}
@@ -626,17 +570,7 @@ public class LineSubCommand extends DecentCommand {
 
 		@Override
 		public TabCompleteHandler getTabCompleteHandler() {
-			return (sender, args) -> {
-				List<String> matches = new ArrayList<>();
-				if (args.length == 1) {
-					putHologramNames(args[0], matches);
-				} else if (args.length == 2) {
-					putPages(args[0], args[1], matches);
-				} else if (args.length == 3) {
-					putLines(args[0], Validator.getInteger(args[1]), args[2], matches);
-				}
-				return matches;
-			};
+			return (sender, args) -> handleCommonArgs(args);
 		}
 
 	}
@@ -678,17 +612,7 @@ public class LineSubCommand extends DecentCommand {
 
 		@Override
 		public TabCompleteHandler getTabCompleteHandler() {
-			return (sender, args) -> {
-				List<String> matches = new ArrayList<>();
-				if (args.length == 1) {
-					putHologramNames(args[0], matches);
-				} else if (args.length == 2) {
-					putPages(args[0], args[1], matches);
-				} else if (args.length == 3) {
-					putLines(args[0], Validator.getInteger(args[1]), args[2], matches);
-				}
-				return matches;
-			};
+			return (sender, args) -> handleCommonArgs(args);
 		}
 
 	}
@@ -728,17 +652,7 @@ public class LineSubCommand extends DecentCommand {
 
 		@Override
 		public TabCompleteHandler getTabCompleteHandler() {
-			return (sender, args) -> {
-				List<String> matches = new ArrayList<>();
-				if (args.length == 1) {
-					putHologramNames(args[0], matches);
-				} else if (args.length == 2) {
-					putPages(args[0], args[1], matches);
-				} else if (args.length == 3) {
-					putLines(args[0], Validator.getInteger(args[1]), args[2], matches);
-				}
-				return matches;
-			};
+			return (sender, args) -> handleCommonArgs(args);
 		}
 
 	}
@@ -775,17 +689,11 @@ public class LineSubCommand extends DecentCommand {
 		@Override
 		public TabCompleteHandler getTabCompleteHandler() {
 			return (sender, args) -> {
-				List<String> matches = new ArrayList<>();
-				if (args.length == 1) {
-					putHologramNames(args[0], matches);
-				} else if (args.length == 2) {
-					putPages(args[0], args[1], matches);
-				} else if (args.length == 3) {
-					putLines(args[0], Validator.getInteger(args[1]), args[2], matches);
-				} else if (args.length >= 4) {
-					putContent(Arrays.copyOfRange(args, 3, args.length), matches);
+				if (args.length <= 3) {
+					return handleCommonArgs(args);
+				} else {
+					return getContent(Arrays.copyOfRange(args, 3, args.length));
 				}
-				return matches;
 			};
 		}
 
@@ -827,17 +735,11 @@ public class LineSubCommand extends DecentCommand {
 		@Override
 		public TabCompleteHandler getTabCompleteHandler() {
 			return (sender, args) -> {
-				List<String> matches = new ArrayList<>();
-				if (args.length == 1) {
-					putHologramNames(args[0], matches);
-				} else if (args.length == 2) {
-					putPages(args[0], args[1], matches);
-				} else if (args.length == 3) {
-					putLines(args[0], Validator.getInteger(args[1]), args[2], matches);
-				} else if (args.length == 4) {
-					putLines(args[0], Validator.getInteger(args[1]), args[3], matches);
+				if (args.length <= 3) {
+					return handleCommonArgs(args);
+				} else {
+					return getLines(args[0], Validator.getInteger(args[1]), args[3]);
 				}
-				return matches;
 			};
 		}
 	}
@@ -881,42 +783,49 @@ public class LineSubCommand extends DecentCommand {
 
 		@Override
 		public TabCompleteHandler getTabCompleteHandler() {
-			return null;
+			return (sender, args) -> {
+				if (args.length <= 3) {
+					return handleCommonArgs(args);
+				} else {
+					return getPartialMatches(args[3], Arrays.asList("NORTH", "EAST", "SOUTH", "WEST"));
+				}
+			};
 		}
 	}
 
 	/*
 	 *	Utility Methods
 	 */
-
-	protected static void putHologramNames(String token, Collection<String> collection) {
-		StringUtil.copyPartialMatches(token, PLUGIN.getHologramManager().getHologramNames(), collection);
-	}
-
-	protected static void putContent(String[] args, Collection<String> collection) {
-		if (args.length == 1 && args[0].toLowerCase(Locale.ROOT).startsWith("#")) {
-			StringUtil.copyPartialMatches(
-				args[0],
-				Arrays.asList("#ICON: ", "#HEAD: ", "#SMALLHEAD: ", "#ENTITY: "), 
-				collection
-			);
+	
+	// Utility method to handle all "/dh <subcommand> <hologram> <page> <line>" stuff
+	protected static List<String> handleCommonArgs(String[] args) {
+		if (args.length == 1) {
+			return getHologramNames(args[0]);
 		} else if (args.length == 2) {
-			switch(args[0].toUpperCase(Locale.ROOT)) {
+			return getPages(args[0], args[1]);
+		} else if (args.length == 3) {
+			return getLines(args[0], Validator.getInteger(args[1]), args[2]);
+		}
+		
+		return Collections.emptyList();
+	}
+	
+	protected static List<String> getHologramNames(String token) {
+		return getPartialMatches(token, PLUGIN.getHologramManager().getHologramNames());
+	}
+	
+	protected static List<String> getContent(String[] args) {
+		if (args.length == 1 && args[0].startsWith("#")) {
+			return getPartialMatches(args[0], Arrays.asList("#ICON: ", "#HEAD: ", "#SMALLHEAD: ", "#ENTITY: "));
+		} else if (args.length == 2) {
+			switch (args[0].toUpperCase(Locale.ROOT)) {
 				case "#ICON:":
 				case "#HEAD:":
 				case "#SMALLHEAD:":
-					StringUtil.copyPartialMatches(
-						args[1],
-						Arrays.stream(Material.values())
-							.filter(DecentMaterial::isItem)
-							.map(Material::name)
-							.collect(Collectors.toList()),
-						collection
-					);
-					break;
+					return getPartialMatches(args[1], items);
 				
 				case "#ENTITY:":
-					StringUtil.copyPartialMatches(args[1], DecentEntityType.getAllowedEntityTypeNames(), collection);
+					return getPartialMatches(args[1], DecentEntityType.getAllowedEntityTypeNames());
 			}
 		} else if (args.length >= 3) {
 			String item = args[1].toUpperCase(Locale.ROOT);
@@ -933,41 +842,68 @@ public class LineSubCommand extends DecentCommand {
 					names.add("(HEADDATABASE_<id>)");
 				}
 				
-				StringUtil.copyPartialMatches(args[2], names, collection);
-				return;
+				return getPartialMatches(args[2], names);
 			}
 			
 			String lastArg = args[args.length - 1];
-			if (lastArg.startsWith("!")) {
-				collection.add("!ENCHANTED");
+			if (lastArg.startsWith("!") && args[0].toUpperCase(Locale.ROOT).startsWith("#ICON:")) {
+				return Collections.singletonList("!ENCHANTED");
 			}
 		}
+		
+		return Collections.emptyList();
 	}
-
-	protected static void putPages(String hologramName, String token, Collection<String> collection) {
+	
+	protected static List<String> getPages(String hologramName, String token) {
 		Hologram hologram = PLUGIN.getHologramManager().getHologram(hologramName);
 		if (hologram != null) {
-			StringUtil.copyPartialMatches(token, IntStream
-					.rangeClosed(1, hologram.size())
-					.boxed().map(String::valueOf)
-					.collect(Collectors.toList()), collection);
+			return getPartialMatches(token, IntStream
+				.rangeClosed(1, hologram.size())
+				.boxed().map(String::valueOf)
+				.collect(Collectors.toList()));
 		}
+		
+		return Collections.emptyList();
 	}
-
-	protected static void putLines(String hologramName, int pageIndex, String token, Collection<String> collection) {
+	
+	protected static List<String> getLines(String hologramName, int pageIndex, String token) {
 		Hologram hologram = PLUGIN.getHologramManager().getHologram(hologramName);
-		if (hologram == null) return;
+		if (hologram == null) return Collections.emptyList();
 		HologramPage page = hologram.getPage(pageIndex - 1);
 		if (page != null) {
-			StringUtil.copyPartialMatches(token, IntStream
-					.rangeClosed(1, page.size())
-					.boxed().map(String::valueOf)
-					.collect(Collectors.toList()), collection);
+			return getPartialMatches(token, IntStream
+				.rangeClosed(1, page.size())
+				.boxed().map(String::valueOf)
+				.collect(Collectors.toList()));
 		}
+		
+		return Collections.emptyList();
 	}
-
-	protected static void putFlags(String token, Collection<String> collection) {
-		StringUtil.copyPartialMatches(token, Arrays.stream(EnumFlag.values()).map(Enum::name).collect(Collectors.toList()), collection);
+	
+	protected static List<String> getFlags(String token) {
+		return getPartialMatches(token, Arrays.stream(EnumFlag.values()).map(Enum::name).collect(Collectors.toList()));
+	}
+	
+	// Slight alteration of Bukkits StringUtil.copyPartialMatches
+	private static List<String> getPartialMatches(String token, Iterable<String> originals) {
+		if (originals == null) {
+			return Collections.emptyList();
+		}
+		
+		if (token == null || token.isEmpty()) {
+			List<String> tmp = new ArrayList<>();
+			originals.iterator().forEachRemaining(tmp::add);
+			return tmp;
+		}
+		
+		List<String> matches = new ArrayList<>();
+		for(String str : originals){
+			if(str.length() >= token.length() && str.regionMatches(true, 0, token, 0, token.length())){
+				matches.add(str);
+			}
+		}
+		
+		return matches;
 	}
 
 }

--- a/src/main/java/eu/decentsoftware/holograms/plugin/commands/LineSubCommand.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/commands/LineSubCommand.java
@@ -885,15 +885,13 @@ public class LineSubCommand extends DecentCommand {
 	}
 	
 	// Slight alteration of Bukkits StringUtil.copyPartialMatches
-	private static List<String> getPartialMatches(String token, Iterable<String> originals) {
+	private static List<String> getPartialMatches(String token, Collection<String> originals) {
 		if (originals == null) {
 			return Collections.emptyList();
 		}
 		
 		if (token == null || token.isEmpty()) {
-			List<String> tmp = new ArrayList<>();
-			originals.iterator().forEachRemaining(tmp::add);
-			return tmp;
+			return new ArrayList<>(originals);
 		}
 		
 		List<String> matches = new ArrayList<>();

--- a/src/main/java/eu/decentsoftware/holograms/plugin/commands/LineSubCommand.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/commands/LineSubCommand.java
@@ -927,13 +927,15 @@ public class LineSubCommand extends DecentCommand {
 			}
 		} else if (args.length >= 3) {
 			if (args[2].startsWith("(") && args.length == 3) {
-				StringUtil.copyPartialMatches(
-					args[2],
-					Bukkit.getOnlinePlayers().stream()
-						.map(player -> "(" + player.getName() + ")")
-						.collect(Collectors.toList()),
-					collection
-				);
+				List<String> names = Bukkit.getOnlinePlayers().stream()
+					.map(player -> "(" + player.getName() + ")")
+					.collect(Collectors.toList());
+				
+				if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
+					names.add("(%player_name%)");
+				}
+				
+				StringUtil.copyPartialMatches(args[2], names, collection);
 				return;
 			}
 			

--- a/src/main/java/eu/decentsoftware/holograms/plugin/commands/LineSubCommand.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/commands/LineSubCommand.java
@@ -846,7 +846,7 @@ public class LineSubCommand extends DecentCommand {
 			}
 			
 			String lastArg = args[args.length - 1];
-			if (lastArg.startsWith("!") && args[0].toUpperCase(Locale.ROOT).startsWith("#ICON:")) {
+			if ("!ENCHANTED".regionMatches(true, 0, lastArg, 0, lastArg.length()) && args[0].toUpperCase(Locale.ROOT).startsWith("#ICON:")) {
 				return Collections.singletonList("!ENCHANTED");
 			}
 		}

--- a/src/main/java/eu/decentsoftware/holograms/plugin/commands/LineSubCommand.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/commands/LineSubCommand.java
@@ -535,7 +535,7 @@ public class LineSubCommand extends DecentCommand {
 				List<String> matches = Lists.newArrayList();
 				if (args.length == 1) {
 					putHologramNames(args[0], matches);
-				} else if (args.length == 2){
+				} else if (args.length == 2) {
 					putPages(args[0], args[1], matches);
 				} else if (args.length == 3) {
 					putLines(args[0], Validator.getInteger(args[1]), args[2], matches);

--- a/src/main/java/eu/decentsoftware/holograms/plugin/commands/LineSubCommand.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/commands/LineSubCommand.java
@@ -919,7 +919,8 @@ public class LineSubCommand extends DecentCommand {
 					StringUtil.copyPartialMatches(args[1], DecentEntityType.getAllowedEntityTypeNames(), collection);
 			}
 		} else if (args.length >= 3) {
-			if (args[2].startsWith("(") && args.length == 3) {
+			String item = args[1].toUpperCase(Locale.ROOT);
+			if (args[2].startsWith("(") && args.length == 3 && (item.contains("HEAD") || item.contains("SKULL"))) {
 				List<String> names = Bukkit.getOnlinePlayers().stream()
 					.map(player -> "(" + player.getName() + ")")
 					.collect(Collectors.toList());

--- a/src/main/java/eu/decentsoftware/holograms/plugin/commands/LineSubCommand.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/commands/LineSubCommand.java
@@ -178,7 +178,7 @@ public class LineSubCommand extends DecentCommand {
 				} else if (args.length == 4) {
 					return getLines(args[0], Validator.getInteger(args[1]), args[3]);
 				} else if (args.length == 5) {
-					return getPartialMatches(args[4], Arrays.asList("X", "Z", "XZ"));
+					return TabCompleteHandler.getPartialMatches(args[4], "X", "Z", "XZ");
 				}
 				
 				return Collections.emptyList();
@@ -787,7 +787,7 @@ public class LineSubCommand extends DecentCommand {
 				if (args.length <= 3) {
 					return handleCommonArgs(args);
 				} else {
-					return getPartialMatches(args[3], Arrays.asList("NORTH", "EAST", "SOUTH", "WEST"));
+					return TabCompleteHandler.getPartialMatches(args[3], "NORTH", "EAST", "SOUTH", "WEST");
 				}
 			};
 		}
@@ -811,25 +811,25 @@ public class LineSubCommand extends DecentCommand {
 	}
 	
 	protected static List<String> getHologramNames(String token) {
-		return getPartialMatches(token, PLUGIN.getHologramManager().getHologramNames());
+		return TabCompleteHandler.getPartialMatches(token, PLUGIN.getHologramManager().getHologramNames());
 	}
 	
 	protected static List<String> getContent(String[] args) {
 		if (args.length == 1 && args[0].startsWith("#")) {
-			return getPartialMatches(args[0], Arrays.asList("#ICON: ", "#HEAD: ", "#SMALLHEAD: ", "#ENTITY: "));
+			return TabCompleteHandler.getPartialMatches(args[0], "#ICON: ", "#HEAD: ", "#SMALLHEAD: ", "#ENTITY: ");
 		} else if (args.length == 2) {
 			switch (args[0].toUpperCase(Locale.ROOT)) {
 				case "#ICON:":
 				case "#HEAD:":
 				case "#SMALLHEAD:":
-					return getPartialMatches(args[1], items);
+					return TabCompleteHandler.getPartialMatches(args[1], items);
 				
 				case "#ENTITY:":
-					return getPartialMatches(args[1], DecentEntityType.getAllowedEntityTypeNames());
+					return TabCompleteHandler.getPartialMatches(args[1], DecentEntityType.getAllowedEntityTypeNames());
 			}
 		} else if (args.length >= 3) {
 			String item = args[1].toUpperCase(Locale.ROOT);
-			if (args[2].startsWith("(") && args.length == 3 && (item.contains("HEAD") || item.contains("SKULL"))) {
+			if (args[2].startsWith("(") && (item.contains("HEAD") || item.contains("SKULL"))) {
 				List<String> names = Bukkit.getOnlinePlayers().stream()
 					.map(player -> "(" + player.getName() + ")")
 					.collect(Collectors.toList());
@@ -842,7 +842,7 @@ public class LineSubCommand extends DecentCommand {
 					names.add("(HEADDATABASE_<id>)");
 				}
 				
-				return getPartialMatches(args[2], names);
+				return TabCompleteHandler.getPartialMatches(args[args.length - 1], names);
 			}
 			
 			String lastArg = args[args.length - 1];
@@ -857,7 +857,7 @@ public class LineSubCommand extends DecentCommand {
 	protected static List<String> getPages(String hologramName, String token) {
 		Hologram hologram = PLUGIN.getHologramManager().getHologram(hologramName);
 		if (hologram != null) {
-			return getPartialMatches(token, IntStream
+			return TabCompleteHandler.getPartialMatches(token, IntStream
 				.rangeClosed(1, hologram.size())
 				.boxed().map(String::valueOf)
 				.collect(Collectors.toList()));
@@ -871,7 +871,7 @@ public class LineSubCommand extends DecentCommand {
 		if (hologram == null) return Collections.emptyList();
 		HologramPage page = hologram.getPage(pageIndex - 1);
 		if (page != null) {
-			return getPartialMatches(token, IntStream
+			return TabCompleteHandler.getPartialMatches(token, IntStream
 				.rangeClosed(1, page.size())
 				.boxed().map(String::valueOf)
 				.collect(Collectors.toList()));
@@ -881,27 +881,7 @@ public class LineSubCommand extends DecentCommand {
 	}
 	
 	protected static List<String> getFlags(String token) {
-		return getPartialMatches(token, Arrays.stream(EnumFlag.values()).map(Enum::name).collect(Collectors.toList()));
-	}
-	
-	// Slight alteration of Bukkits StringUtil.copyPartialMatches
-	private static List<String> getPartialMatches(String token, Collection<String> originals) {
-		if (originals == null) {
-			return Collections.emptyList();
-		}
-		
-		if (token == null || token.isEmpty()) {
-			return new ArrayList<>(originals);
-		}
-		
-		List<String> matches = new ArrayList<>();
-		for(String str : originals){
-			if(str.length() >= token.length() && str.regionMatches(true, 0, token, 0, token.length())){
-				matches.add(str);
-			}
-		}
-		
-		return matches;
+		return TabCompleteHandler.getPartialMatches(token, Arrays.stream(EnumFlag.values()).map(Enum::name).collect(Collectors.toList()));
 	}
 
 }

--- a/src/main/java/eu/decentsoftware/holograms/plugin/commands/LineSubCommand.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/commands/LineSubCommand.java
@@ -121,7 +121,7 @@ public class LineSubCommand extends DecentCommand {
 				} else if (args.length == 2) {
 					putPages(args[0], args[1], matches);
 				} else if (args.length >= 3) {
-					putContent(copyFromIndex(args, 2), matches);
+					putContent(Arrays.copyOfRange(args, 2, args.length), matches);
 				}
 				return matches;
 			};
@@ -540,7 +540,7 @@ public class LineSubCommand extends DecentCommand {
 				} else if (args.length == 3) {
 					putLines(args[0], Validator.getInteger(args[1]), args[2], matches);
 				} else if (args.length >= 4) {
-					putContent(copyFromIndex(args, 3), matches);
+					putContent(Arrays.copyOfRange(args, 3, args.length), matches);
 				}
 				return matches;
 			};
@@ -790,7 +790,7 @@ public class LineSubCommand extends DecentCommand {
 				} else if (args.length == 3) {
 					putLines(args[0], Validator.getInteger(args[1]), args[2], matches);
 				} else if (args.length >= 4) {
-					putContent(copyFromIndex(args, 3), matches);
+					putContent(Arrays.copyOfRange(args, 3, args.length), matches);
 				}
 				return matches;
 			};
@@ -970,20 +970,6 @@ public class LineSubCommand extends DecentCommand {
 
 	protected static void putFlags(String token, Collection<String> collection) {
 		StringUtil.copyPartialMatches(token, Arrays.stream(EnumFlag.values()).map(Enum::name).collect(Collectors.toList()), collection);
-	}
-	
-	// Creates a copy of the provided String array but starting at the provided startIndex.
-	private static String[] copyFromIndex(String[] original, int startIndex) {
-		List<String> tmp = new ArrayList<>();
-		for (int i = 0; i < original.length; i++) {
-			if (i < startIndex) {
-				continue;
-			}
-			
-			tmp.add(original[i]);
-		}
-		
-		return tmp.toArray(new String[0]);
 	}
 
 }

--- a/src/main/java/eu/decentsoftware/holograms/plugin/commands/LineSubCommand.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/commands/LineSubCommand.java
@@ -30,16 +30,9 @@ import java.util.stream.IntStream;
 		aliases = {"line", "l"}
 )
 public class LineSubCommand extends DecentCommand {
-	
-	private static final List<String> lineTypes = new ArrayList<>();
 
 	public LineSubCommand() {
 		super("lines");
-		
-		lineTypes.add("#ICON: ");
-		lineTypes.add("#HEAD: ");
-		lineTypes.add("#SMALLHEAD: ");
-		lineTypes.add("#ENTITY: ");
 
 		addSubCommand(new LineHelpSub());
 		addSubCommand(new LineAddSub());
@@ -904,14 +897,14 @@ public class LineSubCommand extends DecentCommand {
 		if (args.length == 1 && args[0].toLowerCase(Locale.ROOT).startsWith("#")) {
 			StringUtil.copyPartialMatches(
 				args[0],
-				lineTypes,
+				Arrays.asList("#ICON: ", "#HEAD: ", "#SMALLHEAD: ", "#ENTITY: "), 
 				collection
 			);
 		} else if (args.length == 2) {
 			switch(args[0].toUpperCase(Locale.ROOT)) {
 				case "#ICON:":
 				case "#HEAD:":
-				case "#SMALLHEAD":
+				case "#SMALLHEAD:":
 					StringUtil.copyPartialMatches(
 						args[1],
 						Arrays.stream(Material.values())
@@ -933,6 +926,10 @@ public class LineSubCommand extends DecentCommand {
 				
 				if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
 					names.add("(%player_name%)");
+				}
+				
+				if (Bukkit.getPluginManager().isPluginEnabled("HeadDatabase")) {
+					names.add("(HEADDATABASE_<id>)");
 				}
 				
 				StringUtil.copyPartialMatches(args[2], names, collection);

--- a/src/main/java/eu/decentsoftware/holograms/plugin/commands/PageSubCommand.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/commands/PageSubCommand.java
@@ -17,7 +17,6 @@ import eu.decentsoftware.holograms.plugin.Validator;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
-import org.bukkit.util.StringUtil;
 
 import java.util.Arrays;
 import java.util.List;
@@ -149,22 +148,17 @@ public class PageSubCommand extends DecentCommand {
         @Override
         public TabCompleteHandler getTabCompleteHandler() {
             return (sender, args) -> {
-                List<String> matches = Lists.newArrayList();
                 if (args.length == 1) {
-                    StringUtil.copyPartialMatches(args[0], PLUGIN.getHologramManager().getHologramNames(), matches);
+                    return TabCompleteHandler.getPartialMatches(args[0], PLUGIN.getHologramManager().getHologramNames());
                 } else if (args.length == 3 && (args[1].startsWith("#ICON:") || args[1].startsWith("#HEAD:") || args[1].startsWith("#SMALLHEAD:"))) {
-                    StringUtil.copyPartialMatches(
-                            args[2],
-                            Arrays.stream(Material.values())
-                                    .filter(DecentMaterial::isItem)
-                                    .map(Material::name)
-                                    .collect(Collectors.toList()),
-                            matches
-                    );
+                    return TabCompleteHandler.getPartialMatches(args[2], Arrays.stream(Material.values())
+                        .filter(DecentMaterial::isItem)
+                        .map(Material::name)
+                        .collect(Collectors.toList()));
                 } else if (args.length == 3 && args[1].startsWith("#ENTITY:")) {
-                    StringUtil.copyPartialMatches(args[2], DecentEntityType.getAllowedEntityTypeNames(), matches);
+                    return TabCompleteHandler.getPartialMatches(args[2], DecentEntityType.getAllowedEntityTypeNames());
                 }
-                return matches;
+                return null;
             };
         }
     }
@@ -204,30 +198,25 @@ public class PageSubCommand extends DecentCommand {
         @Override
         public TabCompleteHandler getTabCompleteHandler() {
             return (sender, args) -> {
-                List<String> matches = Lists.newArrayList();
                 if (args.length == 1) {
-                    StringUtil.copyPartialMatches(args[0], PLUGIN.getHologramManager().getHologramNames(), matches);
+                    return TabCompleteHandler.getPartialMatches(args[0], PLUGIN.getHologramManager().getHologramNames());
                 } else if (args.length == 2) {
                     Hologram hologram = PLUGIN.getHologramManager().getHologram(args[0]);
                     if (hologram != null) {
-                        StringUtil.copyPartialMatches(args[1], IntStream
-                                .rangeClosed(1, hologram.size())
-                                .boxed().map(String::valueOf)
-                                .collect(Collectors.toList()), matches);
+                        return TabCompleteHandler.getPartialMatches(args[1], IntStream
+                            .rangeClosed(1, hologram.size())
+                            .boxed().map(String::valueOf)
+                            .collect(Collectors.toList()));
                     }
                 } else if (args.length == 4 && (args[2].startsWith("#ICON:") || args[2].startsWith("#HEAD:") || args[2].startsWith("#SMALLHEAD:"))) {
-                    StringUtil.copyPartialMatches(
-                            args[3],
-                            Arrays.stream(Material.values())
-                                    .filter(DecentMaterial::isItem)
-                                    .map(Material::name)
-                                    .collect(Collectors.toList()),
-                            matches
-                    );
+                    return TabCompleteHandler.getPartialMatches(args[2], Arrays.stream(Material.values())
+                        .filter(DecentMaterial::isItem)
+                        .map(Material::name)
+                        .collect(Collectors.toList()));
                 } else if (args.length == 4 && args[2].startsWith("#ENTITY:")) {
-                    StringUtil.copyPartialMatches(args[3], DecentEntityType.getAllowedEntityTypeNames(), matches);
+                    TabCompleteHandler.getPartialMatches(args[3], DecentEntityType.getAllowedEntityTypeNames());
                 }
-                return matches;
+                return null;
             };
         }
 
@@ -305,27 +294,26 @@ public class PageSubCommand extends DecentCommand {
         @Override
         public TabCompleteHandler getTabCompleteHandler() {
             return (sender, args) -> {
-                List<String> matches = Lists.newArrayList();
                 if (args.length == 1) {
-                    StringUtil.copyPartialMatches(args[0], PLUGIN.getHologramManager().getHologramNames(), matches);
+                    return TabCompleteHandler.getPartialMatches(args[0], PLUGIN.getHologramManager().getHologramNames());
                 } else if (args.length == 2) {
                     Hologram hologram = PLUGIN.getHologramManager().getHologram(args[0]);
                     if (hologram != null) {
-                        StringUtil.copyPartialMatches(args[1], IntStream
-                                .rangeClosed(1, hologram.size())
-                                .boxed().map(String::valueOf)
-                                .collect(Collectors.toList()), matches);
+                        return TabCompleteHandler.getPartialMatches(args[1], IntStream
+                            .rangeClosed(1, hologram.size())
+                            .boxed().map(String::valueOf)
+                            .collect(Collectors.toList()));
                     }
                 } else if (args.length == 3) {
                     Hologram hologram = PLUGIN.getHologramManager().getHologram(args[0]);
                     if (hologram != null) {
-                        StringUtil.copyPartialMatches(args[2], IntStream
-                                .rangeClosed(1, hologram.size())
-                                .boxed().map(String::valueOf)
-                                .collect(Collectors.toList()), matches);
+                        return TabCompleteHandler.getPartialMatches(args[1], IntStream
+                            .rangeClosed(1, hologram.size())
+                            .boxed().map(String::valueOf)
+                            .collect(Collectors.toList()));
                     }
                 }
-                return matches;
+                return null;
             };
         }
     }
@@ -597,21 +585,20 @@ public class PageSubCommand extends DecentCommand {
         @Override
         public TabCompleteHandler getTabCompleteHandler() {
             return (sender, args) -> {
-                List<String> matches = Lists.newArrayList();
                 if (args.length == 1) {
-                    StringUtil.copyPartialMatches(args[0], PLUGIN.getHologramManager().getHologramNames(), matches);
+                    return TabCompleteHandler.getPartialMatches(args[0], PLUGIN.getHologramManager().getHologramNames());
                 } else if (args.length == 2) {
                     Hologram hologram = PLUGIN.getHologramManager().getHologram(args[0]);
                     if (hologram != null) {
-                        StringUtil.copyPartialMatches(args[1], IntStream
-                                .rangeClosed(1, hologram.size())
-                                .boxed().map(String::valueOf)
-                                .collect(Collectors.toList()), matches);
+                        return TabCompleteHandler.getPartialMatches(args[1], IntStream
+                            .rangeClosed(1, hologram.size())
+                            .boxed().map(String::valueOf)
+                            .collect(Collectors.toList()));
                     }
                 } else if (args.length == 3) {
-                    StringUtil.copyPartialMatches(args[2], Lists.newArrayList("true", "false"), matches);
+                    return TabCompleteHandler.getPartialMatches(args[2], "true", "false");
                 }
-                return matches;
+                return null;
             };
         }
 


### PR DESCRIPTION
This PR improves the Tab completion for `/dh l ...` subcommands.

Most notably are the following changes:

- Fixed weird checks and lookup for `add` subcommand. (I mentioned this on the Discord server)
- `add`, `set` and `insert` will now suggest the following values:
  - `#ICON:`, `#HEAD`, `#SMALLHEAD` or `#ENTITY` when length of content is 1 and provided text partially matches one of these types.
  - `(<player_name>)` (`<player_name>` being name of the online players) when content length is 3 and 2nd word is containing `HEAD` or `SKULL`.
  - `(%player_name%)` under the above conditions and while PlaceholderAPI is enabled.
  - `(HEADDATABASE_<id>)` (`<id>` is literal) under the above conditions and while HeadDatabase is enabled.
  - `!ENCHANTED` when the content length is at least 3 words, first word starts with `#ICON:` and the current word partially matches `!ENCHANTED`
  - Added missing line tab-completion for `insert` subcommand.
- Added `NORTH`, `EAST`, `SOUTH` and `WEST` tab completion for `setfacing` subcommand.

Preview:
https://gfycat.com/weeklyeveryboutu

![preview gif](https://thumbs.gfycat.com/WeeklyEveryBoutu-size_restricted.gif)