### PR TITLE
Fix update interval being ignored

### DIFF
--- a/src/main/java/eu/decentsoftware/holograms/api/holograms/Hologram.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/holograms/Hologram.java
@@ -147,12 +147,14 @@ public class Hologram extends UpdatingHologramObject implements ITicked {
                 }
             }
 
+            /*
             if (map.containsKey("always-face-player")) {
                 Object afp = map.get("always-face-player");
                 if (afp instanceof Boolean) {
                     page.setAlwaysFacePlayer((boolean) afp);
                 }
             }
+             */
         }
         return hologram;
     }
@@ -216,7 +218,7 @@ public class Hologram extends UpdatingHologramObject implements ITicked {
     @Override
     public void tick() {
         if (tickCounter.get() == getUpdateInterval()) {
-            tickCounter.set(0);
+            tickCounter.set(1);
             updateAll();
             return;
         }
@@ -405,18 +407,23 @@ public class Hologram extends UpdatingHologramObject implements ITicked {
             getViewerPlayers().forEach(this::update);
         }
     }
-
+    
     public void updateAnimations(Player player) {
+        updateAnimations(true, player);
+    }
+    
+    public void updateAnimations(boolean updatePlaceholders, Player player) {
         if (hasFlag(EnumFlag.DISABLE_ANIMATIONS) || !isVisible(player) || !isInUpdateRange(player)) return;
+        
         HologramPage page = getPage(player);
         if (page != null) {
-            page.getLines().forEach(line -> line.updateAnimations(player));
+            page.getLines().forEach(line -> line.updateAnimations(updatePlaceholders, player));
         }
     }
 
     public void updateAnimationsAll() {
         if (isEnabled() && !hasFlag(EnumFlag.DISABLE_ANIMATIONS)) {
-            getViewerPlayers().forEach(this::updateAnimations);
+            getViewerPlayers().forEach(player -> updateAnimations(false, player));
         }
     }
 

--- a/src/main/java/eu/decentsoftware/holograms/api/holograms/HologramLine.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/holograms/HologramLine.java
@@ -391,8 +391,8 @@ public class HologramLine extends HologramObject {
             }
         }
     }
-
-    public void updateAnimations(Player... players) {
+    
+    public void updateAnimations(boolean updatePlaceholders, Player... players) {
         if (!isEnabled() || hasFlag(EnumFlag.DISABLE_ANIMATIONS)) return;
         List<Player> playerList = getPlayers(true, players);
         NMS nms = NMS.getInstance();
@@ -401,7 +401,7 @@ public class HologramLine extends HologramObject {
             if (HologramLineType.TEXT.equals(type)) {
                 UUID uuid = player.getUniqueId();
                 String lastText = lastTextMap.get(uuid);
-                String text = getText(player, true);
+                String text = getText(player, updatePlaceholders);
                 if (!text.equals(lastText)) {
                     lastTextMap.put(uuid, text);
                     nms.updateFakeEntityCustomName(player, text, entityIds[0]);


### PR DESCRIPTION
This fixes a long standing issue where placeholders got updated every tick rather than every `update-interval`.
The reason behind this is as simple as it is stupid: The `tick()` method in the hologram is only calling the `updateAll()` method when the update interval is reached, which would be fine... However! The tick method also calls `updateAnimationsAll()` and does so every tick interval (which is every tick in this case). This method calls a bunch of other methods which in the end calls a `getText` method. This one in question is also parsing placeholders if text is either null or the `update` boolean is true (which it always was)

So... I now changed the methods a bit to pass a boolean to the `getText` method, so that it won't always update.
For backwards compatibility did I add the old `updateAnimations(Player)` method that simply passes true as boolean.

Other noteworthy changes:

- Changed `tickCounter.set(0)` to `tickCounter.set(1)` to fix update intervals having one extra tick (You can observe this with a placeholder that counts ticks such as `%statistic_play_one_minute%`)
- Commented out `if (map.containsKey("always-face-player"))` block just in case this might still trigger stuff...

Closes #41 