### PR TITLE
Fix "Divide by Zero" exception in createGradient

### DIFF
--- a/src/main/java/eu/decentsoftware/holograms/api/convertor/IConvertor.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/convertor/IConvertor.java
@@ -32,6 +32,18 @@ public interface IConvertor {
 	boolean convert(File... files);
 	
 	/**
+	 * Check if a provided file is not null, does exist, is not a folder and has the same name (with extension)
+	 * as provided.
+	 * 
+	 * @param file The file to check.
+	 * @param fileName The file name to check.
+	 * @return true if the aforementioned cases are all true.
+	 */
+	default boolean isValidFile(File file, String fileName) {
+		return (file != null) && file.exists() && !file.isDirectory() && file.getName().equals(fileName);
+	}
+	
+	/**
 	 * Convert the formatting of the lines into one that DecentHolograms can understand.
 	 * 
 	 * @param lines Lines to convert.

--- a/src/main/java/eu/decentsoftware/holograms/api/convertor/IConvertor.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/convertor/IConvertor.java
@@ -32,18 +32,6 @@ public interface IConvertor {
 	boolean convert(File... files);
 	
 	/**
-	 * Check if a provided file is not null, does exist, is not a folder and has the same name (with extension)
-	 * as provided.
-	 * 
-	 * @param file The file to check.
-	 * @param fileName The file name to check.
-	 * @return true if the aforementioned cases are all true.
-	 */
-	default boolean isValidFile(File file, String fileName) {
-		return (file != null) && file.exists() && !file.isDirectory() && file.getName().equals(fileName);
-	}
-	
-	/**
 	 * Convert the formatting of the lines into one that DecentHolograms can understand.
 	 * 
 	 * @param lines Lines to convert.

--- a/src/main/java/eu/decentsoftware/holograms/api/utils/color/IridiumColorAPI.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/utils/color/IridiumColorAPI.java
@@ -12,7 +12,6 @@ import net.md_5.bungee.api.ChatColor;
 import javax.annotation.Nonnull;
 import java.awt.*;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 

--- a/src/main/java/eu/decentsoftware/holograms/api/utils/color/IridiumColorAPI.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/utils/color/IridiumColorAPI.java
@@ -12,6 +12,7 @@ import net.md_5.bungee.api.ChatColor;
 import javax.annotation.Nonnull;
 import java.awt.*;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -190,7 +191,7 @@ public class IridiumColorAPI {
     }
 
     /**
-     * Returns a gradient array of chat colors.
+     * Returns a gradient array of chat colors or just white if {@code step} is 1 or less.
      *
      * @param start The starting color.
      * @param end   The ending color.
@@ -200,6 +201,11 @@ public class IridiumColorAPI {
      */
     @Nonnull
     private static ChatColor[] createGradient(@Nonnull Color start, @Nonnull Color end, int step) {
+        // Return just white if step is 1 or less. Prevents possible "/ by zero" exception.
+        if (step <= 1) {
+            return new ChatColor[]{ChatColor.WHITE, ChatColor.WHITE, ChatColor.WHITE};
+        }
+        
         ChatColor[] colors = new ChatColor[step];
         int stepR = Math.abs(start.getRed() - end.getRed()) / (step - 1);
         int stepG = Math.abs(start.getGreen() - end.getGreen()) / (step - 1);


### PR DESCRIPTION
Should fix an issue where `createGradient` in the IridiumColorAPI throws an `ArithmeticException` with reason `/ by zero` (divide by zero) when the `step` value is 1.

The method now returns a `ChatColor` array filled with `WHITE` whenever the step value is one or less. This hopefully fixes other issues that may appear (i.e. negative int used in a for loop).

The exception in detail (Provided by Santtiago on Discord):
https://pastebin.com/y460dQEW