### PR TITLE
Send success information to player after conversion

### DIFF
--- a/src/main/java/eu/decentsoftware/holograms/api/convertor/IConvertor.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/convertor/IConvertor.java
@@ -1,5 +1,7 @@
 package eu.decentsoftware.holograms.api.convertor;
 
+import eu.decentsoftware.holograms.plugin.convertors.ConvertorRest;
+
 import java.io.File;
 import java.util.List;
 
@@ -11,25 +13,25 @@ public interface IConvertor {
 	/**
 	 * Automatically find a file to convert the holograms from and convert them.
 	 *
-	 * @return Boolean whether the operation was successful.
+	 * @return IConvertorRest with the result of the operation - the success status and the number of converted holograms.
 	 */
-	boolean convert();
+	IConvertorRest convert();
 
 	/**
 	 * Convert holograms from the given file.
 	 *
 	 * @param file Given file.
-	 * @return Boolean whether the operation was successful.
+	 * @return IConvertorRest with the result of the operation - the success status and the number of converted holograms.
 	 */
-	boolean convert(File file);
+	IConvertorRest convert(File file);
 
 	/**
 	 * Convert holograms from all the given files.
 	 *
 	 * @param files Given files.
-	 * @return Boolean whether the operation was successful.
+	 * @return IConvertorRest with the result of the operation - the success status and the number of converted holograms.
 	 */
-	boolean convert(File... files);
+	IConvertorRest convert(File... files);
 	
 	/**
 	 * Convert the formatting of the lines into one that DecentHolograms can understand.

--- a/src/main/java/eu/decentsoftware/holograms/api/convertor/IConvertorRest.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/convertor/IConvertorRest.java
@@ -1,0 +1,22 @@
+package eu.decentsoftware.holograms.api.convertor;
+
+/**
+ * This interface represents a ConvertorRest - conversion result to extract the success boolean and the number of holograms
+ */
+public interface IConvertorRest {
+
+    /**
+     * Allows you to get the success status of conversion.
+     *
+     * @return Boolean whether the operation was successful.
+     */
+    boolean getSuccess();
+
+    /**
+     * Allows you to get the number of all converted holograms.
+     *
+     * @return int
+     */
+    int getCount();
+
+}

--- a/src/main/java/eu/decentsoftware/holograms/plugin/commands/HologramsCommand.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/commands/HologramsCommand.java
@@ -7,11 +7,9 @@ import eu.decentsoftware.holograms.api.holograms.Hologram;
 import eu.decentsoftware.holograms.api.utils.Common;
 import eu.decentsoftware.holograms.api.utils.message.Message;
 import eu.decentsoftware.holograms.plugin.Validator;
-import eu.decentsoftware.holograms.plugin.convertors.CMIConverter;
-import eu.decentsoftware.holograms.plugin.convertors.ConvertorType;
-import eu.decentsoftware.holograms.plugin.convertors.GHoloConverter;
-import eu.decentsoftware.holograms.plugin.convertors.HolographicDisplaysConvertor;
+import eu.decentsoftware.holograms.plugin.convertors.*;
 import org.bukkit.Location;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.util.StringUtil;
 
@@ -271,23 +269,35 @@ public class HologramsCommand extends DecentCommand {
                     return true;
                 }
 
+                long startTime = System.currentTimeMillis();
+
                 switch (convertorType) {
                     case HOLOGRAPHIC_DISPLAYS:
                         Common.tell(sender, "%sConverting from %s", Common.PREFIX, convertorType.getName());
                         if (path != null) {
                             File file = new File(path);
-                            return new HolographicDisplaysConvertor().convert(file);
+
+                            ConvertorRest convertorRest = new HolographicDisplaysConvertor().convert(file);
+                            sendComplete(sender, startTime, convertorRest);
+                            return convertorRest.getSuccess();
                         } else {
-                            return new HolographicDisplaysConvertor().convert();
+                            ConvertorRest convertorRest = new HolographicDisplaysConvertor().convert();
+                            sendComplete(sender, startTime, convertorRest);
+                            return convertorRest.getSuccess();
                         }
                     
                     case GHOLO:
                         Common.tell(sender, "%sConverting from %s", Common.PREFIX, convertorType.getName());
                         if (path != null) {
                             File file = new File(path);
-                            return new GHoloConverter().convert(file);
+
+                            ConvertorRest convertorRest = new GHoloConverter().convert(file);
+                            sendComplete(sender, startTime, convertorRest);
+                            return convertorRest.getSuccess();
                         } else {
-                            return new GHoloConverter().convert();
+                            ConvertorRest convertorRest = new GHoloConverter().convert();
+                            sendComplete(sender, startTime, convertorRest);
+                            return convertorRest.getSuccess();
                         }
                     
                     case CMI:
@@ -295,9 +305,14 @@ public class HologramsCommand extends DecentCommand {
                         Common.tell(sender, "%sNOTE: CMI support is limited!", Common.PREFIX);
                         if (path != null) {
                             File file = new File(path);
-                            return new CMIConverter().convert(file);
+
+                            ConvertorRest convertorRest = new CMIConverter().convert(file);
+                            sendComplete(sender, startTime, convertorRest);
+                            return convertorRest.getSuccess();
                         } else {
-                            return new CMIConverter().convert();
+                            ConvertorRest convertorRest = new CMIConverter().convert();
+                            sendComplete(sender, startTime, convertorRest);
+                            return convertorRest.getSuccess();
                         }
                         
                     default:
@@ -306,6 +321,10 @@ public class HologramsCommand extends DecentCommand {
                 Common.tell(sender, Common.PREFIX + "Plugin '" + args[0] + "' couldn't be found.");
                 return true;
             };
+        }
+
+        public void sendComplete(CommandSender sender, long startTime, ConvertorRest convertorRest) {
+            Common.tell(sender, "%sSuccessfully converted &a%s &7holograms in &a%s", Common.PREFIX, convertorRest.getCount(), (System.currentTimeMillis() - startTime) / 1000f + "s.");
         }
 
         @Override

--- a/src/main/java/eu/decentsoftware/holograms/plugin/convertors/CMIConverter.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/convertors/CMIConverter.java
@@ -20,16 +20,16 @@ public class CMIConverter implements IConvertor {
     private static final DecentHolograms PLUGIN = DecentHologramsAPI.get();
     
     @Override
-    public boolean convert() {
+    public ConvertorRest convert() {
         return convert(new File("plugins/CMI/holograms.yml"));
     }
     
     @Override
-    public boolean convert(File file) {
+    public ConvertorRest convert(File file) {
         Common.log("Converting CMI holograms...");
         if(!ConverterCommon.isValidFile(file, "holograms.yml")){
             Common.log("Invalid file! Need 'holograms.yml'");
-            return false;
+            return new ConvertorRest(false, 0);
         }
         int count = 0;
         Configuration config = new Configuration(PLUGIN.getPlugin(), file);
@@ -51,15 +51,16 @@ public class CMIConverter implements IConvertor {
             count = ConverterCommon.createHologramPages(count, name, loc, pages, PLUGIN);
         }
         Common.log("Successfully converted %d CMI Holograms!", count);
-        return true;
+        return new ConvertorRest(true, count);
     }
     
     @Override
-    public boolean convert(File... files) {
-        for(final File file : files) {
-            this.convert(file);
+    public ConvertorRest convert(File... files) {
+        int summary = 0;
+        for (File file : files) {
+            summary += this.convert(file).getCount();
         }
-        return true;
+        return new ConvertorRest(true, summary);
     }
     
     @Override

--- a/src/main/java/eu/decentsoftware/holograms/plugin/convertors/ConvertorRest.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/convertors/ConvertorRest.java
@@ -1,0 +1,23 @@
+package eu.decentsoftware.holograms.plugin.convertors;
+
+import eu.decentsoftware.holograms.api.convertor.IConvertorRest;
+
+public class ConvertorRest implements IConvertorRest {
+
+    private final boolean success;
+    private final int count;
+
+    public ConvertorRest(boolean success, int count) {
+        this.success = success;
+        this.count = count;
+    }
+
+    public boolean getSuccess() {
+        return success;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+}

--- a/src/main/java/eu/decentsoftware/holograms/plugin/convertors/GHoloConverter.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/convertors/GHoloConverter.java
@@ -22,16 +22,16 @@ public class GHoloConverter implements IConvertor {
     private static final Pattern GRADIENT = Pattern.compile("\\[(#[0-9a-f]{6}) (\\w+) (#[0-9a-f]{6})]", Pattern.CASE_INSENSITIVE);
     
     @Override
-    public boolean convert(){
+    public ConvertorRest convert(){
         return convert(new File("plugins/GHolo/data/h.data"));
     }
     
     @Override
-    public boolean convert(File file) {
+    public ConvertorRest convert(File file) {
         Common.log("Converting GHolo holograms...");
         if (!this.isFileValid(file)) {
             Common.log("Invalid file! Need 'h.data'");
-            return false;
+            return new ConvertorRest(false, 0);
         }
         int count = 0;
         Configuration config = new Configuration(PLUGIN.getPlugin(), file);
@@ -49,15 +49,16 @@ public class GHoloConverter implements IConvertor {
             count = ConverterCommon.createHologram(count, name, location, lines, PLUGIN);
         }
         Common.log("Successfully converted %d GHolo holograms!", count);
-        return true;
+        return new ConvertorRest(true, count);
     }
     
     @Override
-    public boolean convert(File... files) {
+    public ConvertorRest convert(File... files) {
+        int summary = 0;
         for (File file : files) {
-            this.convert(file);
+            summary += this.convert(file).getCount();
         }
-        return true;
+        return new ConvertorRest(true, summary);
     }
     
     private boolean isFileValid(final File file) {

--- a/src/main/java/eu/decentsoftware/holograms/plugin/convertors/HolographicDisplaysConvertor.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/convertors/HolographicDisplaysConvertor.java
@@ -19,16 +19,16 @@ public class HolographicDisplaysConvertor implements IConvertor {
 	private static final DecentHolograms PLUGIN = DecentHologramsAPI.get();
 
 	@Override
-	public boolean convert() {
+	public ConvertorRest convert() {
 		return convert(new File("plugins/HolographicDisplays/database.yml"));
 	}
 
 	@Override
-	public boolean convert(final File file) {
+	public ConvertorRest convert(final File file) {
 		Common.log("Converting HolographicDisplays holograms...");
 		if (!this.isFileValid(file)) {
 			Common.log("Invalid file! Need 'database.yml'");
-			return false;
+			return new ConvertorRest(false, 0);
 		}
 //		Common.log(file.getAbsolutePath());
 		int count = 0;
@@ -45,15 +45,16 @@ public class HolographicDisplaysConvertor implements IConvertor {
 			count = ConverterCommon.createHologram(count, name, location, lines, PLUGIN);
 		}
 		Common.log("Successfully converted %d HolographicDisplays holograms!", count);
-		return true;
+		return new ConvertorRest(true, count);
 	}
 
 	@Override
-	public boolean convert(final File... files) {
-		for (final File file : files) {
-			this.convert(file);
+	public ConvertorRest convert(final File... files) {
+		int summary = 0;
+		for (File file : files) {
+			summary += this.convert(file).getCount();
 		}
-		return true;
+		return new ConvertorRest(true, summary);
 	}
 	
 	@Override


### PR DESCRIPTION
Added sending information to the player after successful conversion of the holograms. It is useful because without it you don't know if the conversion was successful :)

The `convert()` methods in converters now return a new `ConvertorRest` class containing the success of the action (boolean) and the number of holograms converted (methods `getSuccess()` and `getCount()`). This allows the plugin to send the above mentioned success message.