### PR TITLE
Add functionality to (un)load holograms on World (un)load

### DIFF
--- a/src/main/java/eu/decentsoftware/holograms/api/DecentHolograms.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/DecentHolograms.java
@@ -13,6 +13,7 @@ import eu.decentsoftware.holograms.api.utils.Common;
 import eu.decentsoftware.holograms.api.utils.DExecutor;
 import eu.decentsoftware.holograms.api.utils.UpdateChecker;
 import eu.decentsoftware.holograms.api.utils.tick.Ticker;
+import eu.decentsoftware.holograms.api.world.WorldListener;
 import lombok.Getter;
 import org.apache.commons.lang.Validate;
 import org.bstats.bukkit.Metrics;
@@ -68,6 +69,7 @@ public final class DecentHolograms {
 
 		PluginManager pm = Bukkit.getPluginManager();
 		pm.registerEvents(new PlayerListener(this), plugin);
+		pm.registerEvents(new WorldListener(this), plugin);
 //		pm.registerEvents(hologramManager.getOffsetListener(), plugin);
 
 		// Setup metrics

--- a/src/main/java/eu/decentsoftware/holograms/api/holograms/DisableCause.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/holograms/DisableCause.java
@@ -1,0 +1,16 @@
+package eu.decentsoftware.holograms.api.holograms;
+
+/**
+ * Used in {@link eu.decentsoftware.holograms.api.holograms.Hologram#disable(DisableCause) Hologram#disable(DisableCause)}
+ * to set a cause for disabling the Hologram in question.
+ * 
+ * <p>This is mainly used for when a world is loaded to determine, if the Hologram has been unloaded by command, the
+ * API or through the world being unloaded.
+ */
+public enum DisableCause{
+    API,
+    COMMAND,
+    WORLD_UNLOAD,
+    
+    NONE
+}

--- a/src/main/java/eu/decentsoftware/holograms/api/holograms/objects/HologramObject.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/holograms/objects/HologramObject.java
@@ -1,6 +1,8 @@
 package eu.decentsoftware.holograms.api.holograms.objects;
 
 import com.google.common.collect.ImmutableSet;
+import eu.decentsoftware.holograms.api.holograms.DisableCause;
+import eu.decentsoftware.holograms.plugin.Validator;
 import lombok.Getter;
 import lombok.Setter;
 import org.bukkit.Bukkit;
@@ -20,6 +22,7 @@ public abstract class HologramObject extends FlagHolder {
      */
 
     protected boolean enabled = true;
+    protected DisableCause cause = DisableCause.NONE;
     protected final Set<UUID> viewers = Collections.synchronizedSet(new HashSet<>());
     protected Location location;
     protected String permission = null;
@@ -56,6 +59,7 @@ public abstract class HologramObject extends FlagHolder {
      * Enable updating and showing to players automatically.
      */
     public void enable() {
+        this.cause = DisableCause.NONE;
         this.enabled = true;
     }
 
@@ -63,7 +67,33 @@ public abstract class HologramObject extends FlagHolder {
      * Disable updating and showing to players automatically.
      */
     public void disable() {
+        disable(DisableCause.API);
+    }
+    
+    /**
+     * Disable updating and showing to players automatically.
+     * <br>Allows you to set a {@link DisableCause cause} for why the Hologram was disabled.
+     * 
+     * @param cause The cause for why the Hologram was disabled.
+     * 
+     * @throws IllegalArgumentException When {@link DisableCause#NONE NONE} is used as the disable cause.
+     */
+    public void disable(DisableCause cause) {
+        if (cause.equals(DisableCause.NONE))
+            throw new IllegalArgumentException("Cannot use DisableCause NONE while disabling Hologram!");
+        
+        this.cause = cause;
         this.enabled = false;
+    }
+    
+    /**
+     * The cause for disabling the hologram.
+     * <br>May return {@link DisableCause#NONE NONE} if the Hologram is still enabled.
+     * 
+     * @return The cause of why the Hologram is disabled, or {@link DisableCause#NONE NONE} if it is still enabled.
+     */
+    public DisableCause getDisableCause() {
+        return cause;
     }
 
     /**

--- a/src/main/java/eu/decentsoftware/holograms/api/holograms/objects/HologramObject.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/holograms/objects/HologramObject.java
@@ -2,7 +2,6 @@ package eu.decentsoftware.holograms.api.holograms.objects;
 
 import com.google.common.collect.ImmutableSet;
 import eu.decentsoftware.holograms.api.holograms.DisableCause;
-import eu.decentsoftware.holograms.plugin.Validator;
 import lombok.Getter;
 import lombok.Setter;
 import org.bukkit.Bukkit;

--- a/src/main/java/eu/decentsoftware/holograms/api/world/WorldListener.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/world/WorldListener.java
@@ -1,6 +1,7 @@
 package eu.decentsoftware.holograms.api.world;
 
 import eu.decentsoftware.holograms.api.DecentHolograms;
+import eu.decentsoftware.holograms.api.holograms.DisableCause;
 import eu.decentsoftware.holograms.api.holograms.Hologram;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -20,7 +21,7 @@ public class WorldListener implements Listener {
         decentHolograms.getHologramManager().getHolograms().stream()
             .filter(Hologram::isEnabled)
             .filter(hologram -> hologram.getLocation().getWorld().getName().equals(event.getWorld().getName()))
-            .forEach(Hologram::disable);
+            .forEach(hologram -> hologram.disable(DisableCause.WORLD_UNLOAD));
     }
     
     @EventHandler
@@ -28,6 +29,7 @@ public class WorldListener implements Listener {
         decentHolograms.getHologramManager().getHolograms().stream()
             .filter(hologram -> !hologram.isEnabled())
             .filter(hologram -> hologram.getLocation().getWorld().getName().equals(event.getWorld().getName()))
+            .filter(hologram -> hologram.getDisableCause().equals(DisableCause.WORLD_UNLOAD))
             .forEach(Hologram::enable);
     }
 }

--- a/src/main/java/eu/decentsoftware/holograms/api/world/WorldListener.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/world/WorldListener.java
@@ -1,0 +1,33 @@
+package eu.decentsoftware.holograms.api.world;
+
+import eu.decentsoftware.holograms.api.DecentHolograms;
+import eu.decentsoftware.holograms.api.holograms.Hologram;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.world.WorldLoadEvent;
+import org.bukkit.event.world.WorldUnloadEvent;
+
+public class WorldListener implements Listener {
+    
+    private final DecentHolograms decentHolograms;
+    
+    public WorldListener(DecentHolograms decentHolograms) {
+        this.decentHolograms = decentHolograms;
+    }
+    
+    @EventHandler
+    public void onWorldUnload(WorldUnloadEvent event) {
+        decentHolograms.getHologramManager().getHolograms().stream()
+            .filter(Hologram::isEnabled)
+            .filter(hologram -> hologram.getLocation().getWorld().getName().equals(event.getWorld().getName()))
+            .forEach(Hologram::disable);
+    }
+    
+    @EventHandler
+    public void onWorldLoad(WorldLoadEvent event) {
+        decentHolograms.getHologramManager().getHolograms().stream()
+            .filter(hologram -> !hologram.isEnabled())
+            .filter(hologram -> hologram.getLocation().getWorld().getName().equals(event.getWorld().getName()))
+            .forEach(Hologram::enable);
+    }
+}

--- a/src/main/java/eu/decentsoftware/holograms/plugin/commands/HologramSubCommand.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/commands/HologramSubCommand.java
@@ -3,6 +3,7 @@ package eu.decentsoftware.holograms.plugin.commands;
 import com.google.common.collect.Lists;
 import eu.decentsoftware.holograms.api.Lang;
 import eu.decentsoftware.holograms.api.commands.*;
+import eu.decentsoftware.holograms.api.holograms.DisableCause;
 import eu.decentsoftware.holograms.api.holograms.Hologram;
 import eu.decentsoftware.holograms.api.holograms.HologramLine;
 import eu.decentsoftware.holograms.api.holograms.HologramPage;
@@ -378,7 +379,7 @@ public class HologramSubCommand extends DecentCommand {
 					Lang.HOLOGRAM_ALREADY_DISABLED.send(sender);
 					return true;
 				}
-				hologram.disable();
+				hologram.disable(DisableCause.COMMAND);
 				hologram.save();
 
 				Lang.HOLOGRAM_DISABLED.send(sender);


### PR DESCRIPTION
Adds some very basic functionality to unload holograms in a world that has been unloaded, or load those in a world that has been loaded again.

Didn't bother adding any complex mechanic behind this.
Maybe consider an API feature in the future to set what type of enable/disable this was to determine what holograms should be loaded (I.e. those unloaded through commands stay unloaded while does done through automation load again)?