### PR TITLE
Fix IndexOutOfBoundsException for getPage

### DIFF
--- a/src/main/java/eu/decentsoftware/holograms/api/holograms/Hologram.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/holograms/Hologram.java
@@ -592,7 +592,7 @@ public class Hologram extends UpdatingHologramObject implements ITicked {
     }
 
     public HologramPage getPage(int index) {
-        if (index < 0 || index > size()) return null;
+        if (index < 0 || index >= size()) return null;
         return pages.get(index);
     }
 


### PR DESCRIPTION
Fixes the following lines:

```java
public HologramPage getPage(int index) {
    if (index < 0 || index > size()) return null;
    pages.get(index);
}
```
The issue with that code is, that we do remove 1 from the provided page-index in the commands, so f.e. `2` becomes `1`. If a player now tries to provide a value that is larger than the amount of pages (i.e. `2` when there is only one page) will the above if-check fail as in our example, 2 is changed to 1 and 1 is not less than 0 and also not larger than size (1).

TL;DR: Changed `index > size()` to `index >= size()`