### PR TITLE
Allow empty lines on setHologramLines

### DIFF
--- a/src/main/java/eu/decentsoftware/holograms/api/DHAPI.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/DHAPI.java
@@ -822,7 +822,7 @@ public final class DHAPI {
      */
     public static void setHologramLines(Hologram hologram, int pageIndex, List<String> lines) throws IllegalArgumentException {
         Validate.notNull(hologram);
-        if (lines == null || lines.isEmpty()) {
+        if (lines == null) {
             return;
         }
 


### PR DESCRIPTION
If `lines` is empty, the method will remove all lines of the page