### PR TITLE
Clear helmet slot on type change

### DIFF
--- a/src/main/java/eu/decentsoftware/holograms/api/holograms/HologramLine.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/holograms/HologramLine.java
@@ -133,6 +133,7 @@ public class HologramLine extends HologramObject {
     private HologramItem item;
     private HologramEntity entity;
 
+    private boolean clearHelmet;
     private volatile boolean containsAnimations;
     private volatile boolean containsPlaceholders;
 
@@ -219,6 +220,7 @@ public class HologramLine extends HologramObject {
             }
             item = new HologramItem(content.substring("#ICON:".length()));
 
+            clearHelmet = prevType == HologramLineType.HEAD || prevType == HologramLineType.SMALLHEAD;
             containsPlaceholders = PAPI.containsPlaceholders(item.getContent());
         } else if (contentU.startsWith("#SMALLHEAD:")) {
             type = HologramLineType.SMALLHEAD;
@@ -226,17 +228,20 @@ public class HologramLine extends HologramObject {
                 height = Settings.DEFAULT_HEIGHT_SMALLHEAD;
             }
             item = new HologramItem(content.substring("#SMALLHEAD:".length()));
+            clearHelmet = false;
         } else if (contentU.startsWith("#HEAD:")) {
             type = HologramLineType.HEAD;
             if (prevType != type) {
                 height = Settings.DEFAULT_HEIGHT_HEAD;
             }
             item = new HologramItem(content.substring("#HEAD:".length()));
+            clearHelmet = false;
         } else if (contentU.startsWith("#ENTITY:")) {
             type = HologramLineType.ENTITY;
             entity = new HologramEntity(content.substring("#ENTITY:".length()));
             height = NMS.getInstance().getEntityHeight(entity.getType()) + 0.15;
             setOffsetY(-(height + (Version.afterOrEqual(13) ? 0.1 : 0.2)));
+            clearHelmet = prevType == HologramLineType.HEAD || prevType == HologramLineType.SMALLHEAD;
             return;
         } else {
             type = HologramLineType.TEXT;
@@ -245,6 +250,7 @@ public class HologramLine extends HologramObject {
             }
             text = parseCustomReplacements();
 
+            clearHelmet = prevType == HologramLineType.HEAD || prevType == HologramLineType.SMALLHEAD;
             containsAnimations = DECENT_HOLOGRAMS.getAnimationManager().containsAnimations(text);
             containsPlaceholders = PAPI.containsPlaceholders(text);
         }
@@ -487,7 +493,13 @@ public class HologramLine extends HologramObject {
             } else if (type == HologramLineType.HEAD || type == HologramLineType.SMALLHEAD) {
                 nms.helmetFakeEntity(player, HologramItem.parseItemStack(getItem().getContent(), player), entityIds[0]);
             }
+
+            if (clearHelmet) { // Clear the helmet slot if the type no longer a head
+                nms.helmetFakeEntity(player, null, entityIds[0]);
+            }
         }
+
+        clearHelmet = false;
     }
 
     /**

--- a/src/main/java/eu/decentsoftware/holograms/api/nms/versions/NMS_1_17.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/nms/versions/NMS_1_17.java
@@ -375,7 +375,6 @@ public class NMS_1_17 extends NMS {
     @Override
     public void helmetFakeEntity(Player player, ItemStack itemStack, int entityId) {
         Validate.notNull(player);
-        Validate.notNull(itemStack);
 
         List<Object> items = new ArrayList<>();
         items.add(PAIR_OF_METHOD.invokeStatic(ENUM_ITEM_SLOT_FROM_NAME_METHOD.invokeStatic("head"), CRAFT_ITEM_NMS_COPY_METHOD.invokeStatic(itemStack)));

--- a/src/main/java/eu/decentsoftware/holograms/api/nms/versions/NMS_1_8.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/nms/versions/NMS_1_8.java
@@ -140,7 +140,6 @@ public class NMS_1_8 extends NMS {
     @Override
     public void helmetFakeEntity(Player player, ItemStack itemStack, int entityId) {
         Validate.notNull(player);
-        Validate.notNull(itemStack);
         Object nmsItemStack = CRAFT_ITEM_NMS_COPY_METHOD.invokeStatic(itemStack);
         if (nmsItemStack == null) return;
         Object packet = PACKET_ENTITY_EQUIPMENT_CONSTRUCTOR.newInstance(entityId, 4, nmsItemStack);

--- a/src/main/java/eu/decentsoftware/holograms/api/nms/versions/NMS_1_9.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/nms/versions/NMS_1_9.java
@@ -320,7 +320,6 @@ public class NMS_1_9 extends NMS {
     @Override
     public void helmetFakeEntity(Player player, ItemStack itemStack, int entityId) {
         Validate.notNull(player);
-        Validate.notNull(itemStack);
 
         if (ENUM_ITEM_SLOT_HEAD == null) {
             ENUM_ITEM_SLOT_HEAD = ENUM_ITEM_SLOT_FROM_NAME_METHOD.invokeStatic("head");


### PR DESCRIPTION
The helmet slot is never cleared when the type is changed to text, for example. This commit will fix that.