### PR TITLE
Improve Converter path resolving

### DIFF
--- a/src/main/java/eu/decentsoftware/holograms/plugin/convertors/ConvertorType.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/convertors/ConvertorType.java
@@ -9,20 +9,21 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 @Getter
 public enum ConvertorType {
 	CMI(true, "CMI"),
 	FUTURE_HOLOGRAMS(true, "FutureHolograms", "fh", "fholograms"),
 	GHOLO(false, "GHolo", "gh"),
-	HOLOGRAPHIC_DISPLAYS(false, "HolographicDisplays", "HD", "hd"),
+	HOLOGRAPHIC_DISPLAYS(false, "HolographicDisplays", "hd"),
 	HOLOGRAMS(true, "Holograms"),
 	;
 
 	@Nullable
 	public static ConvertorType fromString(String alias) {
 		for (ConvertorType convertorType : ConvertorType.values()) {
-			if (convertorType.getName().equalsIgnoreCase(alias) || convertorType.getAliases().contains(alias)) {
+			if (convertorType.getName().equalsIgnoreCase(alias) || convertorType.getAliases().contains(alias.toLowerCase(Locale.ROOT))) {
 				return convertorType;
 			}
 		}

--- a/src/main/java/eu/decentsoftware/holograms/plugin/convertors/impl/CMIConverter.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/convertors/impl/CMIConverter.java
@@ -23,7 +23,7 @@ public class CMIConverter implements IConvertor {
 
     @Override
     public ConvertorResult convert() {
-        return convert(new File("plugins/CMI/holograms.yml"));
+        return convert(new File(PLUGIN.getDataFolder().getParent() + "/CMI/", "holograms.yml"));
     }
 
     @Override

--- a/src/main/java/eu/decentsoftware/holograms/plugin/convertors/impl/FutureHologramsConverter.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/convertors/impl/FutureHologramsConverter.java
@@ -21,7 +21,7 @@ public class FutureHologramsConverter implements IConvertor {
     
     @Override
     public ConvertorResult convert(){
-        return convert(new File("plugins/FutureHolograms/holograms.yml"));
+        return convert(new File(PLUGIN.getDataFolder().getParent() + "/FutureHolograms/", "holograms.yml"));
     }
     
     @Override

--- a/src/main/java/eu/decentsoftware/holograms/plugin/convertors/impl/GHoloConverter.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/convertors/impl/GHoloConverter.java
@@ -25,7 +25,7 @@ public class GHoloConverter implements IConvertor {
     
     @Override
     public ConvertorResult convert(){
-        return convert(new File("plugins/GHolo/data/h.data"));
+        return convert(new File(PLUGIN.getDataFolder().getParent() + "/GHolo/data/", "h.data"));
     }
     
     @Override

--- a/src/main/java/eu/decentsoftware/holograms/plugin/convertors/impl/HologramsConvertor.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/convertors/impl/HologramsConvertor.java
@@ -22,7 +22,7 @@ public class HologramsConvertor implements IConvertor {
 
     @Override
     public ConvertorResult convert() {
-        return convert(new File("plugins/Holograms/holograms.yml"));
+        return convert(new File(PLUGIN.getDataFolder().getParent() + "/Holograms/", "holograms.yml"));
     }
 
     @Override

--- a/src/main/java/eu/decentsoftware/holograms/plugin/convertors/impl/HolographicDisplaysConvertor.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/convertors/impl/HolographicDisplaysConvertor.java
@@ -12,17 +12,21 @@ import org.bukkit.Location;
 import org.bukkit.configuration.file.YamlConfiguration;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class HolographicDisplaysConvertor implements IConvertor {
 
 	private static final DecentHolograms PLUGIN = DecentHologramsAPI.get();
+	private static final Pattern PAPI_PATTERN = Pattern.compile("\\{papi: (.+)}");
 
 	@Override
 	public ConvertorResult convert() {
-		return convert(new File("plugins/HolographicDisplays/database.yml"));
+		return convert(new File(PLUGIN.getDataFolder().getParent() + "/HolographicDisplays/", "database.yml"));
 	}
 
 	@Override
@@ -51,7 +55,25 @@ public class HolographicDisplaysConvertor implements IConvertor {
 	
 	@Override
 	public List<String> prepareLines(List<String> lines){
-		return lines.stream().map(line -> {
+		List<String> parsed = new ArrayList<>(lines.size());
+		// Go through each line and convert any {papi: <placeholder>} pattern to %<placeholder>%
+		for(String line : lines){
+			String parsedLine = line;
+			Matcher matcher = PAPI_PATTERN.matcher(line);
+			if(matcher.find()){
+				StringBuffer buffer = new StringBuffer();
+				do{
+					matcher.appendReplacement(buffer, "%" + matcher.group(1) + "%");
+				}while(matcher.find());
+				
+				matcher.appendTail(buffer);
+				parsedLine = buffer.toString();
+			}
+			
+			parsed.add(parsedLine);
+		}
+		
+		return parsed.stream().map(line -> {
 			if (line.toUpperCase().startsWith("ICON:")) {
 				return "#" + line;
 			}


### PR DESCRIPTION
This changes the Converters slightly by using `PLUGIN.getDataFolder().getParent()` to have a more consistent way of getting the plugins directory.

In addition have I also modified the `prepareLines` method for the HolographicDisplaysConverter to support converting the (honestly weird) `{papi: <placeholder>}` pattern into the normal `%<placeholder>%` pattern.

If that can be improved in any way, let me know...