### PR TITLE
Fix for #144

### DIFF
--- a/src/main/java/eu/decentsoftware/holograms/api/holograms/Hologram.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/holograms/Hologram.java
@@ -908,7 +908,7 @@ public class Hologram extends UpdatingHologramObject implements ITicked {
     }
 
     public HologramPage removePage(int index) {
-        if (index < 0 || index > size()) {
+        if (index < 0 || index >= size()) {
             return null;
         }
 

--- a/src/main/java/eu/decentsoftware/holograms/plugin/commands/LineSubCommand.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/commands/LineSubCommand.java
@@ -639,7 +639,7 @@ public class LineSubCommand extends DecentCommand {
 				final int index = Validator.getInteger(args[2], Lang.LINE_DOES_NOT_EXIST.getValue());
 				page.removeLine(index - 1);
 				if (page.size() == 0) {
-					hologram.removePage(pageIndex);
+					hologram.removePage(pageIndex - 1);
 					Lang.LINE_REMOVED.send(sender);
 					Lang.PAGE_DELETED.send(sender);
 				} else {


### PR DESCRIPTION
These two changes fix #144

A potential IndexOutOfBoundsException caused by incorrect index checking is fixed.
Missing page number user input to a 0-indexed array index conversion is fixed.