### PR TITLE
Make line add sub-command not player only

### DIFF
--- a/src/main/java/eu/decentsoftware/holograms/plugin/commands/LineSubCommand.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/commands/LineSubCommand.java
@@ -83,7 +83,6 @@ public class LineSubCommand extends DecentCommand {
 			usage = "/dh line add <hologram> <page> [content]",
 			description = "Add a line to Hologram.",
 			aliases = {"append"},
-			playerOnly = true,
 			minArgs = 2
 	)
 	static class LineAddSub extends DecentCommand {


### PR DESCRIPTION
Removing the `playerOnly` annotation from the line add sub command, as it doesn't need to be player only. The code already checks the type of the sender when it needs to.

All the other similar commands - insert, delete etc - work from console.