### PR TITLE
Prioritize texture when parsing item

### DIFF
--- a/src/main/java/eu/decentsoftware/holograms/api/utils/items/HologramItem.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/utils/items/HologramItem.java
@@ -136,10 +136,10 @@ public class HologramItem {
         if (material.name().contains("HEAD") || material.name().contains("SKULL")) {
             String owner = itemBuilder.getSkullOwner();
             String texture = itemBuilder.getSkullTexture();
-            if (owner != null) {
-                stringBuilder.append("(").append(owner).append(")");
-            } else if (texture != null) {
+            if (texture != null) {
                 stringBuilder.append("(").append(texture).append(")");
+            } else if (owner != null && !owner.isEmpty()) {
+                stringBuilder.append("(").append(owner).append(")");
             }
         }
         NBTItem nbtItem = new NBTItem(itemStack);


### PR DESCRIPTION
Since `owner` (`name`) cannot be null in `GameProfile` on recent versions, the check may set the `owner` instead of the `texture`.

