### PR TITLE
Fix file location for CMI converter

### DIFF
--- a/src/main/java/eu/decentsoftware/holograms/plugin/convertors/impl/CMIConverter.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/convertors/impl/CMIConverter.java
@@ -23,7 +23,13 @@ public class CMIConverter implements IConvertor {
 
     @Override
     public ConvertorResult convert() {
-        return convert(new File(PLUGIN.getDataFolder().getParent() + "/CMI/", "holograms.yml"));
+        File file = new File(PLUGIN.getDataFolder().getParent() + "/CMI/Saves/", "holograms.yml");
+        if(ConverterCommon.notValidFile(file, "holograms.yml")){
+            // Probably old location...
+            file = new File(PLUGIN.getDataFolder().getParent() + "/CMI/", "holograms.yml");
+        }
+        
+        return convert(file);
     }
 
     @Override


### PR DESCRIPTION
It seems like CMI now saves the `holograms.yml` file in a `Saves` folder instead of just its plugin folder.

This PR now checks for this file location first and if it is not valid, falls back to the old one for backwards compatability.