### PR TITLE
Set damage display event priority to MONITOR

### DIFF
--- a/src/main/java/eu/decentsoftware/holograms/plugin/features/DamageDisplayFeature.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/features/DamageDisplayFeature.java
@@ -82,7 +82,7 @@ public class DamageDisplayFeature extends AbstractFeature implements Listener {
 		return "Spawn a temporary hologram displaying damage.";
 	}
 
-	@EventHandler(priority = EventPriority.HIGHEST)
+	@EventHandler(priority = EventPriority.MONITOR)
 	public void onDamage(EntityDamageEvent e) {
 		if (e.isCancelled()) {
 			return;


### PR DESCRIPTION
In my testing, changing this event priority allows more compatibility with some plugins such as AdvancedEnchantments which can modify damage output.