### PR TITLE
Improve commands and fix wrong config key

### DIFF
--- a/src/main/java/eu/decentsoftware/holograms/api/Settings.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/Settings.java
@@ -20,7 +20,7 @@ public class Settings {
     public static boolean CHECK_FOR_UPDATES = true;
     @Key(value = "click-cooldown", min = 1, max = 300)
     public static int CLICK_COOLDOWN = 1;
-    @Key("default.text")
+    @Key("defaults.text")
     public static String DEFAULT_TEXT = "Blank Line";
     @Key("defaults.down-origin")
     public static boolean DEFAULT_DOWN_ORIGIN = false;

--- a/src/main/java/eu/decentsoftware/holograms/plugin/commands/HologramSubCommand.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/commands/HologramSubCommand.java
@@ -115,8 +115,8 @@ public class HologramSubCommand extends DecentCommand {
 
 	@CommandInfo(
 			permission = "dh.admin",
-			usage = "/dh hologram align <hologram> <X|Y|Z|XZ> <otherHologram>",
-			description = "Align hologram with other hologram on a specified axis.",
+			usage = "/dh hologram align <hologram> <X|Y|Z|XZ|FACE> <otherHologram>",
+			description = "Align hologram with other hologram on a specified axis or its facing angle.",
 			minArgs = 3
 	)
 	public static class HologramAlignSub extends DecentCommand {
@@ -1095,7 +1095,7 @@ public class HologramSubCommand extends DecentCommand {
 
 	@CommandInfo(
 			permission = "dh.admin",
-			usage = "/dh hologram setupdateinterval <hologram> <range>",
+			usage = "/dh hologram setupdateinterval <hologram> <interval>",
 			description = "Set update interval of a hologram.",
 			aliases = {"updateinterval"},
 			minArgs = 2

--- a/src/main/java/eu/decentsoftware/holograms/plugin/commands/HologramsCommand.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/commands/HologramsCommand.java
@@ -114,8 +114,8 @@ public class HologramsCommand extends DecentCommand {
 
     @CommandInfo(
             permission = "dh.admin",
-            aliases = {"ver", "about"},
             usage = "/dh version",
+            aliases = {"ver", "about"},
             description = "Shows some info about your current DecentHolograms version."
     )
     public static class VersionSubCommand extends DecentCommand {

--- a/src/main/java/eu/decentsoftware/holograms/plugin/commands/LineSubCommand.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/commands/LineSubCommand.java
@@ -122,8 +122,8 @@ public class LineSubCommand extends DecentCommand {
 
 	@CommandInfo(
 			permission = "dh.admin",
-			usage = "/dh line align <hologram> <page> <line1> <line2> <X|Z|XZ>",
-			description = "Align two lines in hologram on a specified axis.",
+			usage = "/dh line align <hologram> <page> <line1> <line2> <X|Z|XZ|FACE>",
+			description = "Align two lines in hologram on a specified axis or its facing angle.",
 			minArgs = 5
 	)
 	static class LineAlignSub extends DecentCommand {
@@ -157,6 +157,10 @@ public class LineSubCommand extends DecentCommand {
 					case "ZX":
 						line1.setOffsetX(line2.getOffsetX());
 						line1.setOffsetZ(line2.getOffsetZ());
+						break;
+					case "FACE":
+					case "FACING":
+						line1.setFacing(line2.getFacing());
 						break;
 					default:
 						Lang.LINE_ALIGN_AXIS.send(sender);

--- a/src/main/java/eu/decentsoftware/holograms/plugin/commands/PageSubCommand.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/commands/PageSubCommand.java
@@ -71,7 +71,7 @@ public class PageSubCommand extends DecentCommand {
 
     @CommandInfo(
             permission = "dh.admin",
-            usage = "/dh page ?",
+            usage = "/dh page help",
             description = "All commands for editing pages.",
             aliases = {"?"}
     )
@@ -360,7 +360,7 @@ public class PageSubCommand extends DecentCommand {
 
     @CommandInfo(
             permission = "dh.admin",
-            usage = "/dh page actions <hologram> <page> <clickType> [page]",
+            usage = "/dh page actions <hologram> <page> <clickType> [listPage]",
             description = "List of click actions.",
             playerOnly = true,
             minArgs = 3


### PR DESCRIPTION
This PR changes some small stuff for commands and also fixes a wrongly asigned config key.


- Fix `DEFAULT_TEXT` key being `default.text` instead of `defaults.text`
- Add `FACE` to hologram align command syntax.
- Added `FACE` option to line align command for feature compat with hologram variant.
- Change `<range>` to `<interval>` in setupdateinterval hologram command.
- Changed `?` to `help` in page help syntax to keep it the same as all other help command syntaxes.