### PR TITLE
Add per-command permissions

### DIFF
--- a/src/main/java/eu/decentsoftware/holograms/api/commands/CommandBase.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/commands/CommandBase.java
@@ -17,7 +17,7 @@ public interface CommandBase {
 	/**
 	 * @return The permission required to execute this Command.
 	 */
-	String getPermission();
+	String[] getPermissions();
 
 	/**
 	 * @return The aliases for this Command.

--- a/src/main/java/eu/decentsoftware/holograms/api/commands/CommandInfo.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/commands/CommandInfo.java
@@ -10,8 +10,8 @@ import java.lang.annotation.Target;
 public @interface CommandInfo {
 
 	String[] aliases() default {};
-
-	String permission();
+	
+	String[] permissions() default {};
 
 	boolean playerOnly() default false;
 

--- a/src/main/java/eu/decentsoftware/holograms/api/commands/CommandValidator.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/commands/CommandValidator.java
@@ -7,7 +7,7 @@ import org.bukkit.entity.Player;
 
 @UtilityClass
 public class CommandValidator {
-
+	
 	/**
 	 * Get the Player from CommandSender if it is a Player.
 	 * <p>
@@ -24,7 +24,7 @@ public class CommandValidator {
 		}
 		return (Player) sender;
 	}
-
+	
 	/**
 	 * Check if String is a valid identifier of Command.
 	 *
@@ -36,7 +36,7 @@ public class CommandValidator {
 		if (identifier.equalsIgnoreCase(commandBase.getName())) {
 			return true;
 		}
-
+		
 		for (String alias : commandBase.getAliases()) {
 			if (identifier.equalsIgnoreCase(alias)) {
 				return true;
@@ -44,7 +44,7 @@ public class CommandValidator {
 		}
 		return false;
 	}
-
+	
 	/**
 	 * Check if CommandSender is allowed to execute Command.
 	 * <p>
@@ -61,15 +61,24 @@ public class CommandValidator {
 			Lang.ONLY_PLAYER.send(sender);
 			return false;
 		}
-
-		String perm = commandBase.getPermission();
-		if (perm != null && !perm.trim().isEmpty() && !sender.hasPermission(perm)) {
+		
+		String[] permissions = commandBase.getPermissions();
+		if (permissions != null && (permissions.length != 0)) {
+			if (sender.hasPermission("dh.admin")) {
+				return true;
+			}
+			
+			for (String permission : permissions) {
+				if (sender.hasPermission(permission))
+					return true;
+			}
+			
 			Lang.NO_PERM.send(sender);
 			return false;
 		}
 		return true;
 	}
-
+	
 	public static int getInteger(String string) {
 		try {
 			return Integer.parseInt(string);

--- a/src/main/java/eu/decentsoftware/holograms/api/commands/DecentCommand.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/commands/DecentCommand.java
@@ -65,8 +65,8 @@ public abstract class DecentCommand extends Command implements CommandBase {
 	}
 
 	@Override
-	public String getPermission() {
-		return info.permission();
+	public String[] getPermissions() {
+		return info.permissions();
 	}
 
 	@Override

--- a/src/main/java/eu/decentsoftware/holograms/plugin/commands/FeatureSubCommand.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/commands/FeatureSubCommand.java
@@ -9,7 +9,7 @@ import eu.decentsoftware.holograms.api.utils.Common;
 import java.util.List;
 
 @CommandInfo(
-		permission = "dh.admin",
+		permissions = "dh.command.features",
 		usage = "/dh features help",
 		description = "All commands for managing features.",
 		aliases = {"feature", "f"}
@@ -50,7 +50,7 @@ public class FeatureSubCommand extends DecentCommand {
      */
 
     @CommandInfo(
-            permission = "dh.admin",
+            permissions = "dh.command.features.disable",
             usage = "/dh feature disable <feature>",
             description = "Disable a Feature.",
             aliases = {"off"},
@@ -93,7 +93,7 @@ public class FeatureSubCommand extends DecentCommand {
     }
 
     @CommandInfo(
-            permission = "dh.admin",
+            permissions = "dh.command.features.enable",
             usage = "/dh feature enable <feature>",
             description = "Enable a Feature.",
             aliases = {"on"},
@@ -136,7 +136,7 @@ public class FeatureSubCommand extends DecentCommand {
     }
 
     @CommandInfo(
-            permission = "dh.admin",
+            permissions = "dh.command.features.help",
             usage = "/dh feature help",
             description = "Show help for features.",
             aliases = {"?"}
@@ -179,7 +179,7 @@ public class FeatureSubCommand extends DecentCommand {
     }
 
     @CommandInfo(
-            permission = "dh.admin",
+            permissions = "dh.command.features.info",
             usage = "/dh feature info <feature>",
             description = "Info about feature.",
             minArgs = 1
@@ -223,7 +223,7 @@ public class FeatureSubCommand extends DecentCommand {
     }
 
     @CommandInfo(
-            permission = "dh.admin",
+            permissions = "dh.command.features.list",
             usage = "/dh feature list",
             description = "List of all features"
     )
@@ -261,7 +261,7 @@ public class FeatureSubCommand extends DecentCommand {
     }
 
     @CommandInfo(
-            permission = "dh.admin",
+            permissions = "dh.command.features.reload",
             usage = "/dh feature reload <feature>",
             description = "Reload a Feature.",
             minArgs = 1

--- a/src/main/java/eu/decentsoftware/holograms/plugin/commands/HologramSubCommand.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/commands/HologramSubCommand.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @CommandInfo(
-		permission = "dh.admin",
+		permissions = "dh.command.holograms",
 		usage = "/dh holograms help",
 		description = "All commands for editing holograms.",
 		aliases = {"hologram", "holo", "h"}
@@ -82,7 +82,7 @@ public class HologramSubCommand extends DecentCommand {
 	 */
 
     @CommandInfo(
-            permission = "dh.admin",
+            permissions = "dh.command.holograms.update",
             usage = "/dh hologram update <hologram>",
             description = "Update a Hologram.",
             minArgs = 1
@@ -114,7 +114,7 @@ public class HologramSubCommand extends DecentCommand {
     }
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.holograms.align",
 			usage = "/dh hologram align <hologram> <X|Y|Z|XZ|FACE> <otherHologram>",
 			description = "Align hologram with other hologram on a specified axis or its facing angle.",
 			minArgs = 3
@@ -184,7 +184,7 @@ public class HologramSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.holograms.center",
 			usage = "/dh hologram center <hologram>",
 			description = "Move a Hologram into the center of a block.",
 			minArgs = 1
@@ -223,7 +223,7 @@ public class HologramSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.holograms.clone",
 			usage = "/dh hologram clone <hologram> <name> [temp] [-l:<world:x:y:z>]",
 			description = "Clone an existing Hologram.",
 			aliases = {"copy"},
@@ -291,7 +291,7 @@ public class HologramSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.holograms.create",
 			usage = "/dh hologram create <name> [-l:world:x:y:z] [content]",
 			description = "Create new Hologram.",
 			aliases = {"new", "c"},
@@ -374,7 +374,7 @@ public class HologramSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.holograms.delete",
 			usage = "/dh hologram delete <hologram>",
 			description = "Delete a Hologram.",
 			aliases = {"del", "remove", "rem"},
@@ -407,7 +407,7 @@ public class HologramSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.holograms.disable",
 			usage = "/dh hologram disable <hologram>",
 			description = "Disable a hologram.",
 			aliases = {"off"},
@@ -443,7 +443,7 @@ public class HologramSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.holograms.setdisplayrange",
 			usage = "/dh hologram setdisplayrange <hologram> <range>",
 			description = "Set display range of a hologram.",
 			aliases = {"displayrange"},
@@ -476,7 +476,7 @@ public class HologramSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.holograms.downorigin",
 			usage = "/dh hologram downorigin <hologram> <true|false>",
 			description = "Set down origin state of the hologram.",
 			aliases = {"setdownorigin"},
@@ -517,7 +517,7 @@ public class HologramSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.holograms.enable",
 			usage = "/dh hologram enable <hologram>",
 			description = "Enable a hologram.",
 			aliases = {"on"},
@@ -553,7 +553,7 @@ public class HologramSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.holograms.setfacing",
 			usage = "/dh hologram setfacing <hologram> <facing>",
 			description = "Set facing direction of a hologram.",
 			aliases = {"facing", "setface", "face"},
@@ -603,7 +603,7 @@ public class HologramSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.holograms.addflag",
 			usage = "/dh hologram addflag <hologram> <flag>",
 			description = "Add a flag to Hologram.",
 			minArgs = 2
@@ -644,7 +644,7 @@ public class HologramSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.holograms.removeflag",
 			usage = "/dh hologram removeflag <hologram> <flag>",
 			description = "Remove a flag from Hologram.",
 			aliases = {"remflag"},
@@ -686,7 +686,7 @@ public class HologramSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.holograms.help",
 			usage = "/dh hologram help",
 			description = "Show help for holograms",
 			aliases = {"?"}
@@ -729,7 +729,7 @@ public class HologramSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.holograms.info",
 			usage = "/dh hologram info <hologram>",
 			description = "Show info about a Hologram.",
 			minArgs = 1
@@ -765,7 +765,7 @@ public class HologramSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.holograms.lines",
 			usage = "/dh hologram lines <hologram> <page> [listPage]",
 			description = "Lists all lines in a hologram.",
 			aliases = {"line", "l"},
@@ -838,7 +838,7 @@ public class HologramSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.holograms.movehere",
 			usage = "/dh hologram movehere <hologram>",
 			description = "Move a Hologram to yourself.",
 			aliases = {"mvhr"},
@@ -879,7 +879,7 @@ public class HologramSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.holograms.move",
 			usage = "/dh hologram move <hologram> <x> <y> <z>",
 			description = "Move Hologram to a Location.",
 			aliases = {"mv"},
@@ -947,7 +947,7 @@ public class HologramSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.holograms.near",
 			usage = "/dh hologram near <range>",
 			description = "List of holograms near you.",
 			playerOnly = true,
@@ -1025,7 +1025,7 @@ public class HologramSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.holograms.setpermission",
 			usage = "/dh hologram setpermission <hologram> [permission]",
 			description = "Set hologram permission.",
 			aliases = {"permission", "setperm", "perm"},
@@ -1061,7 +1061,7 @@ public class HologramSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.holograms.teleport",
 			usage = "/dh hologram teleport <hologram>",
 			description = "Teleport to a Hologram.",
 			playerOnly = true,
@@ -1094,7 +1094,7 @@ public class HologramSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.holograms.setupdateinterval",
 			usage = "/dh hologram setupdateinterval <hologram> <interval>",
 			description = "Set update interval of a hologram.",
 			aliases = {"updateinterval"},
@@ -1127,7 +1127,7 @@ public class HologramSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.holograms.setupdaterange",
 			usage = "/dh hologram setupdaterange <hologram> <range>",
 			description = "Set update range of a hologram.",
 			aliases = {"updaterange"},
@@ -1160,7 +1160,7 @@ public class HologramSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.holograms.rename",
 			usage = "/dh hologram rename <hologram> <new_name>",
 			description = "Rename a hologram.",
 			minArgs = 2

--- a/src/main/java/eu/decentsoftware/holograms/plugin/commands/HologramsCommand.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/commands/HologramsCommand.java
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 
 @CommandInfo(
 		aliases = {"holograms", "hologram", "dh", "holo"},
-		permission = "dh.default",
+		permissions = {"dh.default", "dh.command.decentholograms"},
 		usage = "/dh <args>",
 		description = "The main DecentHolograms Command."
 )
@@ -86,7 +86,7 @@ public class HologramsCommand extends DecentCommand {
      */
 
     @CommandInfo(
-            permission = "dh.admin",
+            permissions = "dh.command.test",
             usage = "/dh test",
             playerOnly = true,
             minArgs = 1,
@@ -113,7 +113,7 @@ public class HologramsCommand extends DecentCommand {
     }
 
     @CommandInfo(
-            permission = "dh.admin",
+            permissions = {"dh.default", "dh.command.version"},
             usage = "/dh version",
             aliases = {"ver", "about"},
             description = "Shows some info about your current DecentHolograms version."
@@ -139,7 +139,7 @@ public class HologramsCommand extends DecentCommand {
     }
 
     @CommandInfo(
-            permission = "dh.admin",
+            permissions = "dh.command.reload",
             usage = "/dh reload",
             description = "Reload the plugin."
     )
@@ -170,7 +170,7 @@ public class HologramsCommand extends DecentCommand {
     }
 
     @CommandInfo(
-            permission = "dh.admin",
+            permissions = "dh.command.list",
             usage = "/dh list [page]",
             description = "Show list of all Holograms.",
             playerOnly = true
@@ -228,7 +228,7 @@ public class HologramsCommand extends DecentCommand {
     }
 
     @CommandInfo(
-            permission = "dh.admin",
+            permissions = "dh.command.help",
             usage = "/dh help",
             description = "Show general help.",
             aliases = {"?"}
@@ -272,7 +272,7 @@ public class HologramsCommand extends DecentCommand {
     }
 
     @CommandInfo(
-            permission = "dh.admin",
+            permissions = "dh.command.convert",
             usage = "/dh convert <plugin> [file]",
             description = "Convert holograms from given plugin.",
             minArgs = 1

--- a/src/main/java/eu/decentsoftware/holograms/plugin/commands/LineSubCommand.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/commands/LineSubCommand.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 @CommandInfo(
-		permission = "dh.admin",
+		permissions = "dh.command.lines",
 		usage = "/dh lines help",
 		description = "All commands for editing hologram lines.",
 		aliases = {"line", "l"}
@@ -79,7 +79,7 @@ public class LineSubCommand extends DecentCommand {
 	 */
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.lines.add",
 			usage = "/dh line add <hologram> <page> [content]",
 			description = "Add a line to Hologram.",
 			aliases = {"append"},
@@ -121,7 +121,7 @@ public class LineSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.lines.align",
 			usage = "/dh line align <hologram> <page> <line1> <line2> <X|Z|XZ|FACE>",
 			description = "Align two lines in hologram on a specified axis or its facing angle.",
 			minArgs = 5
@@ -191,7 +191,7 @@ public class LineSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.lines.edit",
 			usage = "/dh line edit <hologram> <page> <line>",
 			description = "Edit a line.",
 			aliases = {"e"},
@@ -230,7 +230,7 @@ public class LineSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.lines.addflag",
 			usage = "/dh line addflag <hologram> <page> <line> <flag>",
 			description = "Add a flag to line.",
 			minArgs = 4
@@ -274,7 +274,7 @@ public class LineSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.lines.removeflag",
 			usage = "/dh line removeflag <hologram> <page> <line> <flag>",
 			description = "Remove a flag from line.",
 			minArgs = 4
@@ -318,7 +318,7 @@ public class LineSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.lines.height",
 			usage = "/dh line height <hologram> <page> <line> <height>",
 			description = "Set height of a line.",
 			aliases = {"setheight"},
@@ -365,7 +365,7 @@ public class LineSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.lines.help",
 			usage = "/dh line help",
 			description = "Show help for lines.",
 			aliases = {"?"}
@@ -408,7 +408,7 @@ public class LineSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.lines.info",
 			usage = "/dh line info <hologram> <page> <line>",
 			description = "Show info about line.",
 			minArgs = 3
@@ -455,7 +455,7 @@ public class LineSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.lines.insert",
 			usage = "/dh line insert <hologram> <page> <line> [content]",
 			description = "Insert a line into Hologram.",
 			minArgs = 3
@@ -500,7 +500,7 @@ public class LineSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.lines.offsetx",
 			usage = "/dh line offsetX <hologram> <page> <line> <offset>",
 			description = "Set an X offset of a line.",
 			aliases = {"xoffset", "offx", "xoff"},
@@ -540,7 +540,7 @@ public class LineSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.lines.offsetz",
 			usage = "/dh line offsetZ <hologram> <page> <line> <offset>",
 			description = "Set an Z offset of a line.",
 			aliases = {"zoffset", "offz", "zoff"},
@@ -580,7 +580,7 @@ public class LineSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.lines.setpermission",
 			usage = "/dh line setpermission <hologram> <page> <line> [permission]",
 			description = "Set line permission.",
 			aliases = {"permission", "setperm", "perm"},
@@ -622,7 +622,7 @@ public class LineSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.lines.remove",
 			usage = "/dh line remove <hologram> <page> <line>",
 			description = "Remove a line from Hologram.",
 			aliases = {"rem", "del", "delete"},
@@ -662,7 +662,7 @@ public class LineSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.lines.set",
 			usage = "/dh line set <hologram> <page> <line> <content>",
 			description = "Set a line in Hologram.",
 			minArgs = 4
@@ -704,7 +704,7 @@ public class LineSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.lines.swap",
 			usage = "/dh line swap <hologram> <page> <line1> <line2>",
 			description = "Swap two lines in a Hologram.",
 			minArgs = 4
@@ -749,7 +749,7 @@ public class LineSubCommand extends DecentCommand {
 	}
 
 	@CommandInfo(
-			permission = "dh.admin",
+			permissions = "dh.command.lines.setfacing",
 			usage = "/dh line setfacing <hologram> <page> <line> <facing>",
 			description = "Set facing direction of a line.",
 			aliases = {"facing", "setface", "face"},

--- a/src/main/java/eu/decentsoftware/holograms/plugin/commands/PageSubCommand.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/commands/PageSubCommand.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 @CommandInfo(
-        permission = "",
+        permissions = "dh.command.pages",
         usage = "/dh pages help",
         description = "All commands for editing hologram pages.",
         aliases = {"page", "p"}
@@ -70,7 +70,7 @@ public class PageSubCommand extends DecentCommand {
      */
 
     @CommandInfo(
-            permission = "dh.admin",
+            permissions = "dh.command.pages.help",
             usage = "/dh page help",
             description = "All commands for editing pages.",
             aliases = {"?"}
@@ -112,7 +112,7 @@ public class PageSubCommand extends DecentCommand {
     }
 
     @CommandInfo(
-            permission = "dh.admin",
+            permissions = "dh.command.pages.add",
             usage = "/dh page add <hologram> [content]",
             description = "Add a page to Hologram.",
             aliases = {"append"},
@@ -163,7 +163,7 @@ public class PageSubCommand extends DecentCommand {
     }
 
     @CommandInfo(
-            permission = "dh.admin",
+            permissions = "dh.command.pages.insert",
             usage = "/dh page insert <hologram> <page> [content]",
             description = "Insert a page into Hologram.",
             minArgs = 2
@@ -222,7 +222,7 @@ public class PageSubCommand extends DecentCommand {
     }
 
     @CommandInfo(
-            permission = "dh.admin",
+            permissions = "dh.command.pages.remove",
             usage = "/dh page remove <hologram> <page>",
             description = "Remove a page from Hologram.",
             aliases = {"rem", "del", "delete"},
@@ -259,7 +259,7 @@ public class PageSubCommand extends DecentCommand {
     }
 
     @CommandInfo(
-            permission = "dh.admin",
+            permissions = "dh.command.pages.swap",
             usage = "/dh page swap <hologram> <page1> <page2>",
             description = "Swap two pages in a Hologram.",
             minArgs = 3
@@ -318,7 +318,7 @@ public class PageSubCommand extends DecentCommand {
     }
 
     @CommandInfo(
-            permission = "",
+            permissions = "dh.command.pages.switch",
             usage = "/dh page switch <hologram> <page> [player]",
             description = "Switch to a page in hologram.",
             aliases = {"go", "view"},
@@ -359,7 +359,7 @@ public class PageSubCommand extends DecentCommand {
     }
 
     @CommandInfo(
-            permission = "dh.admin",
+            permissions = "dh.command.pages.actions",
             usage = "/dh page actions <hologram> <page> <clickType> [listPage]",
             description = "List of click actions.",
             playerOnly = true,
@@ -406,7 +406,7 @@ public class PageSubCommand extends DecentCommand {
     }
 
     @CommandInfo(
-            permission = "dh.admin",
+            permissions = "dh.command.pages.clearactions",
             usage = "/dh page clearactions <hologram> <page> <clickType>",
             description = "Clear all click actions.",
             minArgs = 3
@@ -450,7 +450,7 @@ public class PageSubCommand extends DecentCommand {
     }
 
     @CommandInfo(
-            permission = "dh.admin",
+            permissions = "dh.command.pages.addactions",
             usage = "/dh page addaction <hologram> <page> <clickType> <action>",
             description = "Add a click action.",
             minArgs = 4
@@ -496,7 +496,7 @@ public class PageSubCommand extends DecentCommand {
     }
 
     @CommandInfo(
-            permission = "dh.admin",
+            permissions = "dh.command.pages.removeaction",
             usage = "/dh page removeaction <hologram> <page> <clickType> <index>",
             description = "Add a click action.",
             aliases = {"remaction"},

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -16,8 +16,298 @@ commands:
     description: "The main command of DecentHolograms plugin."
 
 permissions:
+  #
+  # Main permissions
   dh.admin:
     description: "Allows player to use DecentHolograms."
+    children: 
+      dh.command: true
   dh.default:
     default: true
     description: "Allows player to see the version after using '/decentholograms'."
+    children:
+      dh.command.decentholograms: true
+      dh.command.version: true
+  #
+  # Command permissions
+  dh.command:
+    description: "Allows player to use all commands of DecentHolograms"
+    default: op
+    children:
+      dh.command.decentholograms: true
+      dh.command.version: true
+      dh.command.reload: true
+      dh.command.list: true
+      dh.command.help: true
+      dh.command.convert: true
+      dh.command.features: true
+      dh.command.holograms: true
+      dh.command.lines: true
+      dh.command.pages: true
+  #
+  # Main Command permissions
+  dh.command.decentholograms:
+    description: "Allows player to use the command '/decentholograms'"
+  dh.command.version:
+    description: "Allows player to use the command '/dh version'"
+    default: op
+  dh.command.reload:
+    description: "Allows player to use the command '/dh reload'"
+    default: op
+  dh.command.list:
+    description: "Allows player to use the command '/dh list [page]'"
+    default: op
+  dh.command.help:
+    description: "Allows player to use the command '/dh help'"
+    default: op
+  dh.command.convert:
+    description: "Allows player to use the command '/dh convert <plugin>'"
+    default: op
+  #
+  # Feature Sub-command permissions
+  dh.command.features:
+    description: "Allows player to use the command '/dh features' and all its sub-commands"
+    default: op
+    children: 
+      dh.command.features.disable: true
+      dh.command.features.enable: true
+      dh.command.features.help: true
+      dh.command.features.info: true
+      dh.command.features.list: true
+      dh.command.features.reload: true
+  dh.command.features.disable:
+    description: "Allows player to use the command '/dh features disable <feature>'"
+    default: op
+  dh.command.features.enable:
+    description: "Allows player to use the command '/dh features enable <feature>'"
+    default: op
+  dh.command.features.help:
+    description: "Allows player to use the command '/dh features help'"
+    default: op
+  dh.command.features.info:
+    description: "Allows player to use the command '/dh features info <feature>'"
+    default: op
+  dh.command.features.list:
+    description: "Allows player to use the command '/dh features list'"
+    default: op
+  dh.command.features.reload:
+    description: "Allows player to use the command '/dh features reload'"
+    default: op
+  #
+  # Hologram Sub-command permissions
+  dh.command.holograms:
+    description: "Allows player to use the command '/dh holograms' and all its sub-commands"
+    default: op
+    children: 
+      dh.command.holograms.update: true
+      dh.command.holograms.align: true
+      dh.command.holograms.center: true
+      dh.command.holograms.clone: true
+      dh.command.holograms.create: true
+      dh.command.holograms.delete: true
+      dh.command.holograms.disable: true
+      dh.command.holograms.setdisplayrange: true
+      dh.command.holograms.downorigin: true
+      dh.command.holograms.enable: true
+      dh.command.holograms.setfacing: true
+      dh.command.holograms.addflag: true
+      dh.command.holograms.removeflag: true
+      dh.command.holograms.help: true
+      dh.command.holograms.info: true
+      dh.command.holograms.lines: true
+      dh.command.holograms.movehere: true
+      dh.command.holograms.move: true
+      dh.command.holograms.near: true
+      dh.command.holograms.setpermission: true
+      dh.command.holograms.teleport: true
+      dh.command.holograms.setupdateinterval: true
+      dh.command.holograms.setupdaterange: true
+      dh.command.holograms.rename: true
+  dh.command.holograms.update:
+    description: "Allows player to use the command '/dh holograms update <hologram>'"
+    default: op
+  dh.command.holograms.align:
+    description: "Allows player to use the command '/dh holograms align <hologram> <X|Y|Z|XZ|FACE> <otherHologram>'"
+    default: op
+  dh.command.holograms.center:
+    description: "Allows player to use the command '/dh holograms center <hologram>'"
+    default: op
+  dh.command.holograms.clone:
+    description: "Allows player to use the command '/dh holograms clone <hologram> <name> [temp] [-l:<world>:<x>:<y>:<z>]'"
+    default: op
+  dh.command.holograms.create:
+    description: "Allows player to use the command '/dh holograms create <name> [-l:<world>:<x>:<y>:<z>] [content]'"
+    default: op
+  dh.command.holograms.delete:
+    description: "Allows player to use the command '/dh holograms delete <hologram>'"
+    default: op
+  dh.command.holograms.disable:
+    description: "Allows player to use the command '/dh holograms disable <hologram>'"
+    default: op
+  dh.command.holograms.setdisplayrange:
+    description: "Allows player to use the command '/dh holograms setdisplayrange <hologram> <range>'"
+    default: op
+  dh.command.holograms.downorigin:
+    description: "Allows player to use the command '/dh holograms downorigin <hologram> <true|false>'"
+    default: op
+  dh.command.holograms.enable:
+    description: "Allows player to use the command '/dh holograms enable <hologram>'"
+    default: op
+  dh.command.holograms.setfacing:
+    description: "Allows player to use the command '/dh holograms setfacing <hologram> <facing>'"
+    default: op
+  dh.command.holograms.addflag:
+    description: "Allows player to use the command '/dh holograms addflag <hologram> <flag>'"
+    default: op
+  dh.command.holograms.removeflag:
+    description: "Allows player to use the command '/dh holograms removeflag <hologram> <flag>'"
+    default: op
+  dh.command.holograms.help:
+    description: "Allows player to use the command '/dh holograms help'"
+    default: op
+  dh.command.holograms.info:
+    description: "Allows player to use the command '/dh holograms info <hologram>'"
+    default: op
+  dh.command.holograms.lines:
+    description: "Allows player to use the command '/dh holograms lines <hologram> <page> [listPage]'"
+    default: op
+  dh.command.holograms.movehere:
+    description: "Allows player to use the command '/dh holograms movehere <hologram>'"
+    default: op
+  dh.command.holograms.move:
+    description: "Allows player to use the command '/dh holograms move <hologram> <x> <y> <z>'"
+    default: op
+  dh.command.holograms.near:
+    description: "Allows player to use the command '/dh holograms near <range>'"
+    default: op
+  dh.command.holograms.setpermission:
+    description: "Allows player to use the command '/dh holograms setpermission <hologram> [permission]'"
+    default: op
+  dh.command.holograms.teleport:
+    description: "Allows player to use the command '/dh holograms teleport <hologram>'"
+    default: op
+  dh.command.holograms.setupdateinterval:
+    description: "Allows player to use the command '/dh holograms setupdateinterval <hologram> <interval>'"
+    default: op
+  dh.command.holograms.setupdaterange:
+    description: "Allows player to use the command '/dh holograms setupdaterange <hologram> <range>'"
+    default: op
+  dh.command.holograms.rename:
+    description: "Allows player to use the command '/dh holograms rename <hologram> <new_name>'"
+    default: op
+  #
+  # Line Sub-command permissions
+  dh.command.lines:
+    description: "Allows player to use the command '/dh lines' and all its sub-commands"
+    default: op
+    children: 
+      dh.command.lines.add: true
+      dh.command.lines.align: true
+      dh.command.lines.edit: true
+      dh.command.lines.addflag: true
+      dh.command.lines.removeflag: true
+      dh.command.lines.height: true
+      dh.command.lines.help: true
+      dh.command.lines.info: true
+      dh.command.lines.insert: true
+      dh.command.lines.offsetx: true
+      dh.command.lines.offsetz: true
+      dh.command.lines.setpermission: true
+      dh.command.lines.remove: true
+      dh.command.lines.set: true
+      dh.command.lines.swap: true
+      dh.command.lines.setfacing: true
+  dh.command.lines.add:
+    description: "Allows player to use the command '/dh lines add <hologram> <page> [content]'"
+    default: op
+  dh.command.lines.align:
+    description: "Allows player to use the command '/dh lines align <hologram> <page> <line1> <line2> <X|Z|XZ|FACE>'"
+    default: op
+  dh.command.lines.edit:
+    description: "Allows player to use the command '/dh lines edit <hologram> <page> <line>'"
+    default: op
+  dh.command.lines.addflag:
+    description: "Allows player to use the command '/dh lines addflag <hologram> <page> <line> <flag>'"
+    default: op
+  dh.command.lines.removeflag:
+    description: "Allows player to use the command '/dh lines removeflag <hologram> <page> <line> <flag>'"
+    default: op
+  dh.command.lines.height:
+    description: "Allows player to use the command '/dh lines height <hologram> <page> <line> <height>'"
+    default: op
+  dh.command.lines.help:
+    description: "Allows player to use the command '/dh lines help'"
+    default: op
+  dh.command.lines.info:
+    description: "Allows player to use the command '/dh lines info <hologram> <page> <line>'"
+    default: op
+  dh.command.lines.insert:
+    description: "Allows player to use the command '/dh lines insert <hologram> <page> <line> [content]'"
+    default: op
+  dh.command.lines.offsetx:
+    description: "Allows player to use the command '/dh lines offsetx <hologram> <page> <line> <offset>'"
+    default: op
+  dh.command.lines.offsetz:
+    description: "Allows player to use the command '/dh lines offsetz <hologram> <page> <line> <offset>'"
+    default: op
+  dh.command.lines.setpermission:
+    description: "Allows player to use the command '/dh lines setpermission <hologram> <page> <line> [permission]'"
+    default: op
+  dh.command.lines.remove:
+    description: "Allows player to use the command '/dh lines remove <hologram> <page> <line>'"
+    default: op
+  dh.command.lines.set:
+    description: "Allows player to use the command '/dh lines set <hologram> <page> <line> <content>'"
+    default: op
+  dh.command.lines.swap:
+    description: "Allows player to use the command '/dh lines swap <hologram> <page> <line1> <line2>'"
+    default: op
+  dh.command.lines.setfacing:
+    description: "Allows player to use the command '/dh lines setfacing <hologram> <page> <line> <facing>'"
+    default: op
+  #
+  # Pages Sub-command permissions
+  dh.command.pages:
+    description: "Allows player to use the command '/dh pages' and all its sub-commands"
+    default: op
+    children: 
+      dh.command.pages.help: true
+      dh.command.pages.add: true
+      dh.command.pages.insert: true
+      dh.command.pages.remove: true
+      dh.command.pages.swap: true
+      dh.command.pages.switch: true
+      dh.command.pages.actions: true
+      dh.command.pages.clearactions: true
+      dh.command.pages.addaction: true
+      dh.command.pages.removeaction: true
+  dh.command.pages.help:
+    description: "Allows player to use the command '/dh pages help'"
+    default: op
+  dh.command.pages.add:
+    description: "Allows player to use the command '/dh pages add <hologram> [content]'"
+    default: op
+  dh.command.pages.insert:
+    description: "Allows player to use the command '/dh pages insert <hologram> <page> [content]'"
+    default: op
+  dh.command.pages.remove:
+    description: "Allows player to use the command '/dh pages remove <hologram> <page>'"
+    default: op
+  dh.command.pages.swap:
+    description: "Allows player to use the command '/dh pages swap <hologram> <page1> <page2>'"
+    default: op
+  dh.command.pages.switch:
+    description: "Allows player to use the command '/dh pages switch <hologram> <page> [player]'"
+    default: op
+  dh.command.pages.actions:
+    description: "Allows player to use the command '/dh pages actions <hologram> <page> <clickType> [listPage]'"
+    default: op
+  dh.command.pages.clearactions:
+    description: "Allows player to use the command '/dh pages clearactions <hologram> <page> <clickType>'"
+    default: op
+  dh.command.pages.addaction:
+    description: "Allows player to use the command '/dh pages addaction <hologram> <page> <clickType> <action>'"
+    default: op
+  dh.command.pages.removeaction:
+    description: "Allows player to use the command '/dh pages removeaction <hologram> <page> <clickType> <index>'"
+    default: op


### PR DESCRIPTION
Alters the way permissions are checked by allowing a list of permissions to be defined per-command.

If the list is not empty will DH check if the user has `dh.admin` OR any of the defined permissions.
This should allow more fine-grained permission setups.
Also, I updated the plugins.yml too with the new permissions, so that the server and permission plugins know about the permissions.

Permission format is `dh.command.<subcommand>` for the main sub-command and `dh.command.<subcommand>.<arg>` for an argument of a sub-command.
For example, `dh.command.lines.add` grants access to the `/dh lines add ...` sub-command.

This closes #195 