### PR TITLE
Fix wrong option used for zeroDamage option

### DIFF
--- a/src/main/java/eu/decentsoftware/holograms/plugin/features/DamageDisplayFeature.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/features/DamageDisplayFeature.java
@@ -52,7 +52,7 @@ public class DamageDisplayFeature extends AbstractFeature implements Listener {
 
 		displayForPlayers = config.getBoolean("damage-display.players", displayForPlayers);
 		displayForMobs = config.getBoolean("damage-display.mobs", displayForMobs);
-		zeroDamage = config.getBoolean("damage-display.mobs", zeroDamage);
+		zeroDamage = config.getBoolean("damage-display.zero-damage", zeroDamage);
 
 		if (enabled) {
 			this.enable();


### PR DESCRIPTION
There is a mistake where the damage display uses the `mobs` option instead of `zero-damage` when setting the boolean for whether to display values below or equal to 0 damage.