### PR TITLE
Fix Item NBT not working on 1.20.5+

### DIFF
--- a/src/main/java/eu/decentsoftware/holograms/plugin/DecentHologramsPlugin.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/DecentHologramsPlugin.java
@@ -1,5 +1,6 @@
 package eu.decentsoftware.holograms.plugin;
 
+import de.tr7zw.changeme.nbtapi.NBT;
 import eu.decentsoftware.holograms.api.DecentHolograms;
 import eu.decentsoftware.holograms.api.DecentHologramsAPI;
 import eu.decentsoftware.holograms.api.commands.CommandManager;
@@ -44,6 +45,9 @@ public class DecentHologramsPlugin extends JavaPlugin {
 		DecentCommand mainCommand = new HologramsCommand();
 		commandManager.setMainCommand(mainCommand);
 		commandManager.registerCommand(mainCommand);
+		
+		// Enable NBT API to avoid lag spikes when parsing NBT for the first time.
+		NBT.preloadApi();
 	}
 
 	@Override


### PR DESCRIPTION
This fixes the long-standing issue of Item NBT such as `CustomModelData` not working on 1.20.5+ due to the Item Structure having been redone as a whole.

The PR makes use of NBT API, which is shaded into DecentHolograms, do convert the old NBT structure to the new one.
In more detail is it creating an NBT data instance from the ItemStack, applies the NBT provided by the string as `tag` NBT part and then converts it from 1.20.4 Item NBT to the Item NBT used in the server, before converting this final NBT into an ItemStack to return.

This only happens when the Server version is 1.20.5+, with older versions falling back to the currently used method.

Unlike #229 which focuses only on CustomModelData to be fixed, does this fix other NBT data too such as item color and alike (Granted that NBT API is capable of recognizing and properly converting the data found).

Huge credits go to @tr7zw for their help on Discord with fixing this issue.