### PR TITLE
Change how DH gets Worlds.

### DIFF
--- a/src/main/java/eu/decentsoftware/holograms/api/utils/location/LocationUtils.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/utils/location/LocationUtils.java
@@ -78,14 +78,22 @@ public class LocationUtils {
 
     // Plugins like GHolo use the world's UUID instead of the name for location.
     private static World getWorld(@NonNull String value) {
-        UUID uuid = null;
-        try {
-            uuid = UUID.fromString(value);
-        } catch (IllegalArgumentException ignored) {
-            // Not a UUID
+        World world = Bukkit.getWorld(value);
+        if (world != null) {
+            return world;
         }
 
-        return uuid == null ? Bukkit.getWorld(value) : Bukkit.getWorld(uuid);
+        try {
+            UUID uuid = UUID.fromString(value);
+            world = Bukkit.getWorld(uuid);
+        } catch (IllegalArgumentException ignored) {}
+
+        // World was neither retrieved from name nor UUID. How is this possible?
+        if (world == null) {
+            Log.warn("Cannot retrieve World from value %s!", value);
+        }
+
+        return world;
     }
 
 }

--- a/src/main/java/eu/decentsoftware/holograms/api/utils/location/LocationUtils.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/utils/location/LocationUtils.java
@@ -90,7 +90,7 @@ public class LocationUtils {
 
         // World was neither retrieved from name nor UUID. How is this possible?
         if (world == null) {
-            Log.warn("Cannot retrieve World from value %s!", value);
+            Log.warn("Cannot retrieve World from value %s! It's neither a valid name nor UUID.", value);
         }
 
         return world;


### PR DESCRIPTION
Closes #228 

There seems to be an issue with getting the world when it is in the pattern of `a-b-c-d-e`.
The issue is most likely the `UUID.fromString(value)` method detecting the string as a UUID, returning an instance, even if it was invalid. And given DH only checks if UUID is not null does this result in it trying to return the World from that UUID, which may not work.

This PR changes the logic to first try and get the world by its name. If that fails (world is null) will it try to parse a UUID and get the world through that.
It will also log a failed retrieval if the world is still null after UUID parsing, either due to a failed parsing or because no world was found by the UUID.