### PR TITLE
Fix `HologramItem.fromItemStack(ItemStack)` not including custom model data.

### DIFF
--- a/src/main/java/eu/decentsoftware/holograms/api/utils/items/HologramItem.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/utils/items/HologramItem.java
@@ -1,7 +1,6 @@
 package eu.decentsoftware.holograms.api.utils.items;
 
 import de.tr7zw.changeme.nbtapi.NBT;
-import de.tr7zw.changeme.nbtapi.NBTItem;
 import de.tr7zw.changeme.nbtapi.iface.ReadWriteNBT;
 import de.tr7zw.changeme.nbtapi.utils.DataFixerUtil;
 import eu.decentsoftware.holograms.api.utils.HeadDatabaseUtils;


### PR DESCRIPTION
Changes the `fromItemStack(ItemStack)` method to now check for `CustomModelData` or `minecraft:custom_model_data` in an item's `tag` or `components` compount respectively, depending on the version.

This fixes an issue where custom model data is no longer applied to the final String for the HologramItem when used on 1.20.5+, as DH looks for `CustomModelData`.

In addition was the `NBTItem` replaced with `ReadAndWriteNBT` due to the former being deprecated, while also making sure to check in the Item's `tag` or `components` part respectively.

A test jar shared on Discord shows to fix the issue.