### PR TITLE
Fix resolvable profile error for setting/getting textures.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 defaultTasks "build"
 
 group "eu.decentsoftware.holograms"
-version "2.8.11"
+version "2.8.12"
 description "A lightweight yet very powerful hologram plugin with many features and configuration options."
 
 repositories {

--- a/src/main/java/eu/decentsoftware/holograms/api/utils/items/SkullUtils.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/utils/items/SkullUtils.java
@@ -44,8 +44,9 @@ public final class SkullUtils {
 	private static Field PROFILE_FIELD;
 	private static Method SET_PROFILE_METHOD;
 	private static boolean INITIALIZED = false;
-	private static boolean INITIALIZED_SET_PROFILE = false;
+
 	private static Constructor<?> RESOLVABLE_PROFILE_CONSTRUCTOR;
+	private static Field GAME_PROFILE_FIELD_RESOLVABLE_PROFILE;
 
 	private static Method PROPERTY_VALUE_METHOD;
 	private static Function<Property, String> VALUE_RESOLVER;
@@ -54,6 +55,9 @@ public final class SkullUtils {
 		try {
 			Class<?> resolvableProfileClass = ReflectionUtil.getNMClass("world.item.component.ResolvableProfile");
 			RESOLVABLE_PROFILE_CONSTRUCTOR = resolvableProfileClass == null ? null : resolvableProfileClass.getConstructor(GameProfile.class);
+
+			// find the game profile field in the resolvable profile class
+			GAME_PROFILE_FIELD_RESOLVABLE_PROFILE = ReflectionUtil.findField(resolvableProfileClass, GameProfile.class);
 		} catch ( NoSuchMethodException ignored) {
 			// old version, no resolvable profile class.
 		}
@@ -72,13 +76,12 @@ public final class SkullUtils {
 			if (!(meta instanceof SkullMeta)) {
 				return null;
 			}
-
 			if (PROFILE_FIELD == null) {
 				PROFILE_FIELD = meta.getClass().getDeclaredField("profile");
 				PROFILE_FIELD.setAccessible(true);
 			}
 
-			GameProfile profile = (GameProfile) PROFILE_FIELD.get(meta);
+			GameProfile profile = (GameProfile) (GAME_PROFILE_FIELD_RESOLVABLE_PROFILE == null ? PROFILE_FIELD.get(meta) : GAME_PROFILE_FIELD_RESOLVABLE_PROFILE.get(PROFILE_FIELD.get(meta)));
 			if (profile == null) {
 				return null;
 			}

--- a/src/main/java/eu/decentsoftware/holograms/api/utils/items/SkullUtils.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/utils/items/SkullUtils.java
@@ -76,15 +76,17 @@ public final class SkullUtils {
 			if (!(meta instanceof SkullMeta)) {
 				return null;
 			}
+			// private ResolvableProfile profile;
+
 			if (PROFILE_FIELD == null) {
 				PROFILE_FIELD = meta.getClass().getDeclaredField("profile");
 				PROFILE_FIELD.setAccessible(true);
 			}
+			Object profileObject = PROFILE_FIELD.get(meta);
+			if (profileObject == null) return null;
 
-			GameProfile profile = (GameProfile) (GAME_PROFILE_FIELD_RESOLVABLE_PROFILE == null ? PROFILE_FIELD.get(meta) : GAME_PROFILE_FIELD_RESOLVABLE_PROFILE.get(PROFILE_FIELD.get(meta)));
-			if (profile == null) {
-				return null;
-			}
+			GameProfile profile = (GameProfile) (GAME_PROFILE_FIELD_RESOLVABLE_PROFILE == null ? profileObject : GAME_PROFILE_FIELD_RESOLVABLE_PROFILE.get(profileObject));
+			if (profile == null) return null;
 
 			if (VALUE_RESOLVER == null) {
 				try {

--- a/src/main/java/eu/decentsoftware/holograms/api/utils/items/SkullUtils.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/utils/items/SkullUtils.java
@@ -44,6 +44,7 @@ public final class SkullUtils {
 	private static Field PROFILE_FIELD;
 	private static Method SET_PROFILE_METHOD;
 	private static boolean INITIALIZED = false;
+	private static boolean INITIALIZED_SET_PROFILE = false;
 	private static Constructor<?> RESOLVABLE_PROFILE_CONSTRUCTOR;
 
 	private static Method PROPERTY_VALUE_METHOD;
@@ -145,7 +146,7 @@ public final class SkullUtils {
 					try {
 						// This method only exists in versions 1.16 and up. For older versions, we use reflection
 						// to set the profile field directly.
-						SET_PROFILE_METHOD = meta.getClass().getDeclaredMethod("setProfile", RESOLVABLE_PROFILE_CONSTRUCTOR == null ? GameProfile.class : RESOLVABLE_PROFILE_CONSTRUCTOR.getClass());
+						SET_PROFILE_METHOD = meta.getClass().getDeclaredMethod("setProfile", RESOLVABLE_PROFILE_CONSTRUCTOR == null ? GameProfile.class : RESOLVABLE_PROFILE_CONSTRUCTOR.getDeclaringClass());
 						SET_PROFILE_METHOD.setAccessible(true);
 					} catch (NoSuchMethodException e) {
 						// Server is running an older version.

--- a/src/main/java/eu/decentsoftware/holograms/api/utils/items/SkullUtils.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/utils/items/SkullUtils.java
@@ -4,6 +4,7 @@ import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import com.mojang.authlib.properties.PropertyMap;
 import eu.decentsoftware.holograms.api.utils.Log;
+import eu.decentsoftware.holograms.api.utils.reflect.ReflectionUtil;
 import eu.decentsoftware.holograms.api.utils.reflect.Version;
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
@@ -50,9 +51,9 @@ public final class SkullUtils {
 
 	static {
 		try {
-			Class<?> resolvableProfileClass = Class.forName("net.minecraft.world.item.component.ResolvableProfile");
-			RESOLVABLE_PROFILE_CONSTRUCTOR = resolvableProfileClass.getConstructor(GameProfile.class);
-		} catch (ClassNotFoundException | NoSuchMethodException ignored) {
+			Class<?> resolvableProfileClass = ReflectionUtil.getNMClass("world.item.component.ResolvableProfile");
+			RESOLVABLE_PROFILE_CONSTRUCTOR = resolvableProfileClass == null ? null : resolvableProfileClass.getConstructor(GameProfile.class);
+		} catch ( NoSuchMethodException ignored) {
 			// old version, no resolvable profile class.
 		}
 	}

--- a/src/main/java/eu/decentsoftware/holograms/api/utils/items/SkullUtils.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/utils/items/SkullUtils.java
@@ -7,6 +7,7 @@ import eu.decentsoftware.holograms.api.utils.Log;
 import eu.decentsoftware.holograms.api.utils.reflect.Version;
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
+import org.bukkit.Bukkit;
 import org.bukkit.SkullType;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -18,6 +19,7 @@ import org.json.simple.parser.JSONParser;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -41,9 +43,19 @@ public final class SkullUtils {
 	private static Field PROFILE_FIELD;
 	private static Method SET_PROFILE_METHOD;
 	private static boolean INITIALIZED = false;
+	private static Constructor<?> RESOLVABLE_PROFILE_CONSTRUCTOR;
 
 	private static Method PROPERTY_VALUE_METHOD;
 	private static Function<Property, String> VALUE_RESOLVER;
+
+	static {
+		try {
+			Class<?> resolvableProfileClass = Class.forName("net.minecraft.world.item.component.ResolvableProfile");
+			RESOLVABLE_PROFILE_CONSTRUCTOR = resolvableProfileClass.getConstructor(GameProfile.class);
+		} catch (ClassNotFoundException | NoSuchMethodException ignored) {
+			// old version, no resolvable profile class.
+		}
+	}
 
 	/**
 	 * Get the Base64 texture of the given skull ItemStack.
@@ -128,12 +140,11 @@ public final class SkullUtils {
 
 				PropertyMap properties = profile.getProperties();
 				properties.put("textures", property);
-
 				if (SET_PROFILE_METHOD == null && !INITIALIZED) {
 					try {
 						// This method only exists in versions 1.16 and up. For older versions, we use reflection
 						// to set the profile field directly.
-						SET_PROFILE_METHOD = meta.getClass().getDeclaredMethod("setProfile", GameProfile.class);
+						SET_PROFILE_METHOD = meta.getClass().getDeclaredMethod("setProfile", RESOLVABLE_PROFILE_CONSTRUCTOR == null ? GameProfile.class : RESOLVABLE_PROFILE_CONSTRUCTOR.getClass());
 						SET_PROFILE_METHOD.setAccessible(true);
 					} catch (NoSuchMethodException e) {
 						// Server is running an older version.
@@ -142,7 +153,7 @@ public final class SkullUtils {
 				}
 
 				if (SET_PROFILE_METHOD != null) {
-					SET_PROFILE_METHOD.invoke(meta, profile);
+					SET_PROFILE_METHOD.invoke(meta, RESOLVABLE_PROFILE_CONSTRUCTOR == null ? profile : RESOLVABLE_PROFILE_CONSTRUCTOR.newInstance(profile));
 				} else {
 					if (PROFILE_FIELD == null) {
 						PROFILE_FIELD = meta.getClass().getDeclaredField("profile");

--- a/src/main/java/eu/decentsoftware/holograms/api/utils/reflect/ReflectionUtil.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/utils/reflect/ReflectionUtil.java
@@ -72,6 +72,28 @@ public class ReflectionUtil {
     }
 
     /**
+     * Find a field with in a class with a specific type.
+     * <p>
+     * If the field is not found, this method will return null.
+     *
+     * @param clazz     The class to get the field from.
+     * @param type      The class type of the field.
+     * @return The field, or null if the field was not found.
+     */
+    public static Field findField(Class<?> clazz, Class<?> type) {
+        if (clazz == null) return null;
+
+        Field[] methods = clazz.getDeclaredFields();
+        for (Field method : methods) {
+            if (!method.getType().equals(type)) continue;
+
+            method.setAccessible(true);
+            return method;
+        }
+        return null;
+    }
+
+    /**
      * Get a field with the given name from the given class.
      * <p>
      * If the field is not found, this method will return null.


### PR DESCRIPTION
I've created a fix for the new commit that Spigot has made [here](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/commits/8d52226914ce4b99f35be3d6954f35616d92476d#src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java) that changes the CraftMetaSkull class to use a new component ResolveableProfile, that prevented from setting/getting textures due to this change. 