### PR TITLE
Allow inserting hologram lines at the end of the list

### DIFF
--- a/src/main/java/eu/decentsoftware/holograms/api/holograms/HologramPage.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/holograms/HologramPage.java
@@ -158,10 +158,7 @@ public class HologramPage extends FlagHolder {
      * @see eu.decentsoftware.holograms.api.DHAPI#addHologramLine(HologramPage, String)
      */
     public boolean addLine(@NonNull HologramLine line) {
-        lines.add(line);
-        parent.getViewerPlayers(this.index).forEach(line::show);
-        realignLines();
-        return true;
+        return insertLine(size(), line);
     }
 
     /**

--- a/src/main/java/eu/decentsoftware/holograms/api/holograms/HologramPage.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/holograms/HologramPage.java
@@ -173,7 +173,7 @@ public class HologramPage extends FlagHolder {
      * @see eu.decentsoftware.holograms.api.DHAPI#insertHologramLine(Hologram, int, String)
      */
     public boolean insertLine(int index, @NonNull HologramLine line) {
-        if (index < 0 || index >= size()) {
+        if (index < 0 || index > size()) {
             return false;
         }
         lines.add(index, line);


### PR DESCRIPTION
Closes #267 
Previously, inserting at the end of the hologram required workarounds as the index check did not permit it. This change updates the logic to allow an index equal to `size()`, enabling straightforward insertion at the end. It improves functionality and aligns with expected behavior.