### PR TITLE
Refactor Hologram constructors to enforce non-null config

### DIFF
--- a/src/main/java/eu/decentsoftware/holograms/api/holograms/Hologram.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/holograms/Hologram.java
@@ -27,7 +27,6 @@ import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.util.Collection;
@@ -266,7 +265,7 @@ public class Hologram extends UpdatingHologramObject implements ITicked {
      * @see eu.decentsoftware.holograms.api.DHAPI#createHologram(String, Location, boolean)
      */
     public Hologram(@NonNull String name, @NonNull Location location, boolean saveToFile) {
-        this(name, location, saveToFile ? new FileConfig(DECENT_HOLOGRAMS.getPlugin(), String.format("holograms/%s.yml", name)) : null);
+        this(name, location, new FileConfig(DECENT_HOLOGRAMS.getPlugin(), String.format("holograms/%s.yml", name)), true, saveToFile);
     }
 
     /**
@@ -276,7 +275,7 @@ public class Hologram extends UpdatingHologramObject implements ITicked {
      * @param location The location of the hologram.
      * @param config   The config of the hologram.
      */
-    public Hologram(@NonNull String name, @NonNull Location location, @Nullable FileConfig config) {
+    public Hologram(@NonNull String name, @NonNull Location location, @NonNull FileConfig config) {
         this(name, location, config, true);
     }
 
@@ -288,12 +287,25 @@ public class Hologram extends UpdatingHologramObject implements ITicked {
      * @param config   The config of the hologram.
      * @param enabled  Whether the hologram should be enabled.
      */
-    public Hologram(@NonNull String name, @NonNull Location location, @Nullable FileConfig config, boolean enabled) {
+    public Hologram(@NonNull String name, @NonNull Location location, @NonNull FileConfig config, boolean enabled) {
+        this(name, location, config, enabled, true);
+    }
+
+    /**
+     * Creates a new Hologram with the given parameters.
+     *
+     * @param name       The name of the hologram.
+     * @param location   The location of the hologram.
+     * @param config     The config of the hologram.
+     * @param enabled    Whether the hologram should be enabled.
+     * @param saveToFile Whether the hologram should be saved to a file.
+     */
+    public Hologram(@NonNull String name, @NonNull Location location, @NonNull FileConfig config, boolean enabled, boolean saveToFile) {
         super(location);
-        this.name = name;
         this.config = config;
         this.enabled = enabled;
-        this.saveToFile = this.config != null;
+        this.name = name;
+        this.saveToFile = saveToFile;
         this.tickCounter = new AtomicInteger();
         this.addPage();
         this.register();
@@ -346,9 +358,7 @@ public class Hologram extends UpdatingHologramObject implements ITicked {
     @Override
     public void delete() {
         super.delete();
-        if (config != null) {
-            config.delete();
-        }
+        config.delete();
     }
 
     /**


### PR DESCRIPTION
Closes #265 
Updated constructors to require non-null `FileConfig` and added an overloaded constructor with a `saveToFile` parameter. Simplified `delete()` method by removing a null check on the config.