### PR TITLE
Fix NoSuchElementException on packet handler adding

### DIFF
--- a/src/main/java/eu/decentsoftware/holograms/api/nms/PacketListener.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/nms/PacketListener.java
@@ -1,6 +1,5 @@
 package eu.decentsoftware.holograms.api.nms;
 
-import com.google.common.collect.Iterables;
 import eu.decentsoftware.holograms.api.utils.Log;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoop;
@@ -35,8 +34,9 @@ public class PacketListener {
             try {
                 pipeline.addBefore("packet_handler", IDENTIFIER, new PacketHandlerCustom(player));
             } catch (NoSuchElementException e) {
-                List<String> names = pipeline.names();
-                if (DEFAULT_PIPELINE_TAIL.equals(Iterables.getFirst(names, null))) { // player disconnecting
+                List<String> handlers = pipeline.names();
+                if (handlers.size() == 1 && handlers.iterator().next().equals(DEFAULT_PIPELINE_TAIL)) {
+                    // player disconnecting
                     return;
                 }
                 throw e;


### PR DESCRIPTION
Unnecessary exception suppression for #219 

This exception occurs before a player is disconnected from the server under unspecified conditions.
Nevertheless, it does not affect the plugin's functionality in any way, so I think it is correct to simply hide this exception.
`DefaultChannelPipeline$TailContext#0` is netty handler, so it would be stable on most versions of server software.
Tested on Paper 1.16.5 and Paper 1.21.4. But i was unable to reproduce the NoSuchElementException firing.