### PR TITLE
Fix connection issues within SkullUtils for fetching UUID and texture

### DIFF
--- a/src/main/java/eu/decentsoftware/holograms/api/Settings.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/Settings.java
@@ -64,6 +64,8 @@ public class Settings {
      */
     @Key("holograms-eye-level-positioning")
     public static boolean HOLOGRAMS_EYE_LEVEL_POSITIONING = false;
+    @Key(value = "player-skin-connection-timeout", min = 1, max = 60)
+    public static int PLAYER_SKIN_CONNECTION_TIMEOUT = 5;
 
     public static Map<String, String> CUSTOM_REPLACEMENTS = ImmutableMap.<String, String>builder()
             .put("[x]", "\u2588")

--- a/src/main/java/eu/decentsoftware/holograms/api/utils/items/ItemBuilder.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/utils/items/ItemBuilder.java
@@ -293,7 +293,7 @@ public class ItemBuilder implements Cloneable {
 		 * If the player is offline, we want to fetch the texture ourselves. This is because
 		 * if the server is NOT in online mode, it will not be able to fetch the texture from Mojang.
 		 */
-		final String texture = SkullUtils.getTextureFromURLByPlayerName(playerName);
+		final String texture = SkullUtils.getCachedOrFetchFromUsername(playerName);
 		if (texture != null) {
 			SkullUtils.setSkullTexture(itemStack, texture);
 		}

--- a/src/main/java/eu/decentsoftware/holograms/api/utils/items/SkullUtils.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/utils/items/SkullUtils.java
@@ -246,7 +246,8 @@ public final class SkullUtils {
 
             return data.get("value").toString();
         } catch (Exception e) {
-            Log.warn("Failed to fetch texture for player %s", username, e);
+            Log.warn("Failed to fetch texture for player %s", username);
+            Log.warn("Cause: %s", e.getMessage());
         }
         return null;
     }
@@ -271,7 +272,8 @@ public final class SkullUtils {
                 return jsonData.get("id").toString();
             }
         } catch (Exception e) {
-            Log.warn("Failed to fetch UUID for player %s", playerName, e);
+            Log.warn("Failed to fetch UUID for player %s", playerName);
+            Log.warn("Cause: %s", e.getMessage());
         }
         return null;
     }
@@ -289,8 +291,8 @@ public final class SkullUtils {
         URLConnection connection = null;
         try {
             connection = new URL(urlString).openConnection();
-            connection.setConnectTimeout(50);
-            connection.setReadTimeout(50);
+            connection.setConnectTimeout(500);
+            connection.setReadTimeout(500);
             reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
             StringBuilder builder = new StringBuilder();
             int read;

--- a/src/main/java/eu/decentsoftware/holograms/api/utils/items/SkullUtils.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/utils/items/SkullUtils.java
@@ -247,8 +247,7 @@ public final class SkullUtils {
 
             return data.get("value").toString();
         } catch (Exception e) {
-            Log.warn("Failed to fetch texture for player %s", username);
-            Log.warn("Cause: %s", e.getMessage());
+            Log.warn("Failed to fetch texture for player %s (%s). Cause: %s", username, uuid, e.getMessage());
         }
         return null;
     }
@@ -273,8 +272,7 @@ public final class SkullUtils {
                 return jsonData.get("id").toString();
             }
         } catch (Exception e) {
-            Log.warn("Failed to fetch UUID for player %s", playerName);
-            Log.warn("Cause: %s", e.getMessage());
+            Log.warn("Failed to fetch UUID for player %s. Cause: %s", playerName, e.getMessage());
         }
         return null;
     }
@@ -291,9 +289,11 @@ public final class SkullUtils {
         BufferedReader reader = null;
         URLConnection connection = null;
         try {
+            // Obtain the Timeout in milliseconds by multiplying it by 1000.
+            int timeout = Settings.PLAYER_SKIN_CONNECTION_TIMEOUT * 1000;
             connection = new URL(urlString).openConnection();
-            connection.setConnectTimeout(Settings.PLAYER_SKIN_CONNECTION_TIMEOUT * 1000);
-            connection.setReadTimeout(Settings.PLAYER_SKIN_CONNECTION_TIMEOUT * 1000);
+            connection.setConnectTimeout(timeout);
+            connection.setReadTimeout(timeout);
             reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
             StringBuilder builder = new StringBuilder();
             int read;

--- a/src/main/java/eu/decentsoftware/holograms/api/utils/items/SkullUtils.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/utils/items/SkullUtils.java
@@ -3,6 +3,7 @@ package eu.decentsoftware.holograms.api.utils.items;
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import com.mojang.authlib.properties.PropertyMap;
+import eu.decentsoftware.holograms.api.Settings;
 import eu.decentsoftware.holograms.api.utils.Log;
 import eu.decentsoftware.holograms.api.utils.reflect.ReflectionUtil;
 import eu.decentsoftware.holograms.api.utils.reflect.Version;
@@ -291,8 +292,8 @@ public final class SkullUtils {
         URLConnection connection = null;
         try {
             connection = new URL(urlString).openConnection();
-            connection.setConnectTimeout(500);
-            connection.setReadTimeout(500);
+            connection.setConnectTimeout(Settings.PLAYER_SKIN_CONNECTION_TIMEOUT * 1000);
+            connection.setReadTimeout(Settings.PLAYER_SKIN_CONNECTION_TIMEOUT * 1000);
             reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
             StringBuilder builder = new StringBuilder();
             int read;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -70,6 +70,19 @@ update-visibility-on-teleport: false
 # When disabled, holograms will be positioned at the player's feet height when created or moved (default).
 holograms-eye-level-positioning: false
 
+#
+# Sets the time in seconds that DecentHolograms should have when trying to fetch Skin data for players both
+# by name and UUID.
+# Value can go as low as 1 second and as high as 60 seconds.
+#
+# Note: Increasing this value can have a negative impact on your server's performance, especially on bad
+#       internet connections.
+#       You should only ever change this if you encounter the following warning:
+#
+#       Failed to fetch UUID for player <player>
+#       Cause: Connect|Read timed out
+player-skin-connection-timeout: 5
+
 
 
 # # # # # # # # # # # # # # # # #


### PR DESCRIPTION
This addresses 2 issues within SkullUtils when fetching A player's UUID or texture:

1. It provides the actual cause when a request fails with an exception.
  The order of arguments for the `Log.warn` was wrong, causing the exception to be "swallowed".
  To fix this, and to not spam the console with stacktraces, did I add a separate line listing the cause.
2. The timeout has been increased from 50ms to 5 seconds.
  Having a timeout of just 50ms is barely anything, as a request seems to take around a second at least, so a timeout of 5 seconds was set here.
  I cannot say if there is any performance impact here, but I doubt it to be much.