### PR TITLE
feat: add support for all players page switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ ehthumbs_vista.db
 [Dd]esktop.ini
 $RECYCLE.BIN/
 *.lnk
+
+### VSCode ###
+/.vscode/

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "eu.decentsoftware.holograms"
-version = "2.8.17"
+version = "2.8.18"
 description = "A lightweight yet very powerful hologram plugin with many features and configuration options."
 
 repositories {

--- a/src/main/java/eu/decentsoftware/holograms/plugin/commands/PageSubCommand.java
+++ b/src/main/java/eu/decentsoftware/holograms/plugin/commands/PageSubCommand.java
@@ -336,6 +336,12 @@ public class PageSubCommand extends DecentCommand {
                     return true;
                 }
                 if (args.length > 2 && sender.hasPermission("dh.admin")) {
+                    if (args[2].equals("*")) {
+                        for (Player player : Bukkit.getOnlinePlayers()) {
+                            hologram.show(player, index);
+                        }
+                        return true;
+                    }
                     Player player = Bukkit.getPlayer(args[2]);
                     if (player != null && player.isOnline()) {
                         hologram.show(player, index);


### PR DESCRIPTION
## Feature request

One of the users of a plugin of mine wanted to allow switching pages of a hologram for everyone, but this does not seem possible right now, only per player.

This feature adds the option to use `*` instead of a player name to switch the pages for everyone.

## Considerations

I'm not familiar with the codebase, if there is a better way to do this please enlighten me.