### PR TITLE
Add HologramLoadEvent and HologramUnloadEvent

### DIFF
--- a/plugin/src/main/java/eu/decentsoftware/holograms/api/holograms/Hologram.java
+++ b/plugin/src/main/java/eu/decentsoftware/holograms/api/holograms/Hologram.java
@@ -415,6 +415,7 @@ public class Hologram extends UpdatingHologramObject implements ITicked {
             this.showAll();
             this.register();
         }
+        EventFactory.fireHologramLoadEvent(this);
     }
 
     /**
@@ -428,6 +429,7 @@ public class Hologram extends UpdatingHologramObject implements ITicked {
             this.hideAll();
             super.disable(cause);
         }
+        EventFactory.fireHologramUnloadEvent(this);
     }
 
     @Override

--- a/plugin/src/main/java/eu/decentsoftware/holograms/api/holograms/HologramManager.java
+++ b/plugin/src/main/java/eu/decentsoftware/holograms/api/holograms/HologramManager.java
@@ -5,6 +5,7 @@ import eu.decentsoftware.holograms.api.Settings;
 import eu.decentsoftware.holograms.api.actions.ClickType;
 import eu.decentsoftware.holograms.api.utils.Common;
 import eu.decentsoftware.holograms.api.utils.Log;
+import eu.decentsoftware.holograms.api.utils.event.EventFactory;
 import eu.decentsoftware.holograms.api.utils.exception.LocationParseException;
 import eu.decentsoftware.holograms.api.utils.file.FileUtils;
 import eu.decentsoftware.holograms.api.utils.scheduler.S;
@@ -271,6 +272,7 @@ public class HologramManager extends Ticked {
      */
     public void registerHologram(@NonNull Hologram hologram) {
         hologramMap.put(hologram.getName(), hologram);
+        EventFactory.fireHologramLoadEvent(hologram);
     }
 
     /**

--- a/plugin/src/main/java/eu/decentsoftware/holograms/api/utils/event/EventFactory.java
+++ b/plugin/src/main/java/eu/decentsoftware/holograms/api/utils/event/EventFactory.java
@@ -50,19 +50,12 @@ public class EventFactory {
         Bukkit.getPluginManager().callEvent(event);
     }
     
-    /**
-     * Fire a Hologram load event.
-     *
-     * @param hologram The hologram that gets loaded.
-     *
-     * @see HologramLoadEvent
-     */
     public static void fireHologramLoadEvent(Hologram hologram) {
         if (HologramLoadEvent.getHandlerList().getRegisteredListeners().length == 0) {
             return;
         }
-
-        HologramLoadEvent event = new HologramLoadEvent(hologram);
+        
+        HologramLoadEvent event = new HologramLoadEvent(!Bukkit.isPrimaryThread(), hologram);
         Bukkit.getPluginManager().callEvent(event);
     }
     
@@ -78,7 +71,7 @@ public class EventFactory {
             return;
         }
 
-        HologramUnloadEvent event = new HologramUnloadEvent(hologram);
+        HologramUnloadEvent event = new HologramUnloadEvent(!Bukkit.isPrimaryThread(), hologram);
         Bukkit.getPluginManager().callEvent(event);
     }
 

--- a/plugin/src/main/java/eu/decentsoftware/holograms/api/utils/event/EventFactory.java
+++ b/plugin/src/main/java/eu/decentsoftware/holograms/api/utils/event/EventFactory.java
@@ -3,8 +3,7 @@ package eu.decentsoftware.holograms.api.utils.event;
 import eu.decentsoftware.holograms.api.actions.ClickType;
 import eu.decentsoftware.holograms.api.holograms.Hologram;
 import eu.decentsoftware.holograms.api.holograms.HologramPage;
-import eu.decentsoftware.holograms.event.DecentHologramsReloadEvent;
-import eu.decentsoftware.holograms.event.HologramClickEvent;
+import eu.decentsoftware.holograms.event.*;
 import lombok.experimental.UtilityClass;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -48,6 +47,38 @@ public class EventFactory {
         }
 
         DecentHologramsReloadEvent event = new DecentHologramsReloadEvent();
+        Bukkit.getPluginManager().callEvent(event);
+    }
+    
+    /**
+     * Fire a Hologram load event.
+     *
+     * @param hologram The hologram that gets loaded.
+     *
+     * @see HologramLoadEvent
+     */
+    public static void fireHologramLoadEvent(Hologram hologram) {
+        if (HologramLoadEvent.getHandlerList().getRegisteredListeners().length == 0) {
+            return;
+        }
+
+        HologramLoadEvent event = new HologramLoadEvent(hologram);
+        Bukkit.getPluginManager().callEvent(event);
+    }
+    
+    /**
+     * Fire a Hologram unload event.
+     *
+     * @param hologram The hologram that gets unloaded.
+     *
+     * @see HologramUnloadEvent
+     */
+    public static void fireHologramUnloadEvent(Hologram hologram) {
+        if (HologramUnloadEvent.getHandlerList().getRegisteredListeners().length == 0) {
+            return;
+        }
+
+        HologramUnloadEvent event = new HologramUnloadEvent(hologram);
         Bukkit.getPluginManager().callEvent(event);
     }
 

--- a/plugin/src/main/java/eu/decentsoftware/holograms/event/HologramLoadEvent.java
+++ b/plugin/src/main/java/eu/decentsoftware/holograms/event/HologramLoadEvent.java
@@ -1,36 +1,30 @@
 package eu.decentsoftware.holograms.event;
 
 import eu.decentsoftware.holograms.api.holograms.Hologram;
+import lombok.Getter;
 import org.bukkit.event.HandlerList;
 
 /**
- * This event is called whenever a Hologram is loaded via
- * {@link Hologram#enable()}
+ * This event is fired whenever a Hologram is loaded.
  */
+@Getter
 public class HologramLoadEvent extends DecentHologramsEvent{
-
+    
     private static final HandlerList HANDLERS = new HandlerList();
-
+    
     private final Hologram hologram;
-
-    public HologramLoadEvent(Hologram hologram){
+    
+    public HologramLoadEvent(boolean async, Hologram hologram) {
+        super(async);
         this.hologram = hologram;
     }
-
+    
     @Override
     public HandlerList getHandlers() {
-        return null;
-    }
-
-    public static HandlerList getHandlerList() {
         return HANDLERS;
     }
-
-    /**
-     * The {@link Hologram} that gets loaded.
-     * @return The Hologram that gets loaded.
-     */
-    public Hologram getHologram() {
-        return hologram;
+    
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
     }
 }

--- a/plugin/src/main/java/eu/decentsoftware/holograms/event/HologramLoadEvent.java
+++ b/plugin/src/main/java/eu/decentsoftware/holograms/event/HologramLoadEvent.java
@@ -1,0 +1,36 @@
+package eu.decentsoftware.holograms.event;
+
+import eu.decentsoftware.holograms.api.holograms.Hologram;
+import org.bukkit.event.HandlerList;
+
+/**
+ * This event is called whenever a Hologram is loaded via
+ * {@link Hologram#enable()}
+ */
+public class HologramLoadEvent extends DecentHologramsEvent{
+
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    private final Hologram hologram;
+
+    public HologramLoadEvent(Hologram hologram){
+        this.hologram = hologram;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return null;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+
+    /**
+     * The {@link Hologram} that gets loaded.
+     * @return The Hologram that gets loaded.
+     */
+    public Hologram getHologram() {
+        return hologram;
+    }
+}

--- a/plugin/src/main/java/eu/decentsoftware/holograms/event/HologramUnloadEvent.java
+++ b/plugin/src/main/java/eu/decentsoftware/holograms/event/HologramUnloadEvent.java
@@ -1,35 +1,30 @@
 package eu.decentsoftware.holograms.event;
 
 import eu.decentsoftware.holograms.api.holograms.Hologram;
+import lombok.Getter;
 import org.bukkit.event.HandlerList;
 
 /**
  * This event is called whenever a Hologram is unloaded via
  * {@link Hologram#disable(eu.decentsoftware.holograms.api.holograms.DisableCause)}
  */
+@Getter
 public class HologramUnloadEvent extends DecentHologramsEvent{
 
     private static final HandlerList HANDLERS = new HandlerList();
     private final Hologram hologram;
 
-    public HologramUnloadEvent(Hologram hologram) {
+    public HologramUnloadEvent(boolean isAsync, Hologram hologram) {
+        super(isAsync);
         this.hologram = hologram;
     }
 
     @Override
     public HandlerList getHandlers() {
-        return null;
+        return HANDLERS;
     }
 
     public static HandlerList getHandlerList() {
         return HANDLERS;
-    }
-
-    /**
-     * The {@link Hologram} that gets unloaded.
-     * @return The Hologram that gets unloaded.
-     */
-    public Hologram getHologram() {
-        return hologram;
     }
 }

--- a/plugin/src/main/java/eu/decentsoftware/holograms/event/HologramUnloadEvent.java
+++ b/plugin/src/main/java/eu/decentsoftware/holograms/event/HologramUnloadEvent.java
@@ -1,0 +1,35 @@
+package eu.decentsoftware.holograms.event;
+
+import eu.decentsoftware.holograms.api.holograms.Hologram;
+import org.bukkit.event.HandlerList;
+
+/**
+ * This event is called whenever a Hologram is unloaded via
+ * {@link Hologram#disable(eu.decentsoftware.holograms.api.holograms.DisableCause)}
+ */
+public class HologramUnloadEvent extends DecentHologramsEvent{
+
+    private static final HandlerList HANDLERS = new HandlerList();
+    private final Hologram hologram;
+
+    public HologramUnloadEvent(Hologram hologram) {
+        this.hologram = hologram;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return null;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+
+    /**
+     * The {@link Hologram} that gets unloaded.
+     * @return The Hologram that gets unloaded.
+     */
+    public Hologram getHologram() {
+        return hologram;
+    }
+}


### PR DESCRIPTION
This adds events for when a Hologram gets loaded or unloaded.

I'm not sure on the places where this event should be called, so this should be considered.

Initial testing worked relatively well with only some (a)sync call issues that were fixed using `Bukkit.isPrimaryThread()`


https://github.com/user-attachments/assets/2684882f-e520-4119-bac7-d20c7075c31a

