### PR TITLE
Fix NoSuchFieldError for DROPPED_ITEM in Minecraft 1.21+

### DIFF
--- a/plugin/src/main/java/eu/decentsoftware/holograms/api/nms/versions/NMS_1_17.java
+++ b/plugin/src/main/java/eu/decentsoftware/holograms/api/nms/versions/NMS_1_17.java
@@ -507,9 +507,18 @@ public class NMS_1_17 extends NMS {
         Validate.notNull(location);
         Validate.notNull(itemStack);
 
+        EntityType dropType;
+
+        try {
+            dropType = EntityType.valueOf("DROPPED_ITEM"); 
+        } catch (IllegalArgumentException e) {
+            // 1.21+ 
+            dropType = EntityType.valueOf("ITEM");
+        }
+	    
         List<Object> dataWatcherItems = new ArrayList<>();
         dataWatcherItems.add(DATA_WATCHER_ITEM_CONSTRUCTOR.newInstance(DWO_ITEM, CRAFT_ITEM_NMS_COPY_METHOD.invokeStatic(itemStack)));
-        showFakeEntity(player, location, getEntityTypeId(EntityType.DROPPED_ITEM), entityId);
+        showFakeEntity(player, location, getEntityTypeId(dropType), entityId);
         sendEntityMetadata(player, entityId, dataWatcherItems);
         teleportFakeEntity(player, location, entityId);
     }


### PR DESCRIPTION
Fixing entity type error (1.21+)

Enum:
https://helpch.at/docs/1.21/org/bukkit/entity/EntityType.html

Exception:
org.bukkit.entity.EntityType does not have member field 'org.bukkit.entity.EntityType DROPPED_ITEM'