### PR TITLE
#349 Fix entity dismount on 1.8 - swapped entity ids

### DIFF
--- a/nms/nms-v1_8_R1/src/main/java/eu/decentsoftware/holograms/nms/v1_8_R1/EntityHologramRenderer.java
+++ b/nms/nms-v1_8_R1/src/main/java/eu/decentsoftware/holograms/nms/v1_8_R1/EntityHologramRenderer.java
@@ -35,7 +35,7 @@ class EntityHologramRenderer implements NmsEntityHologramRenderer {
                 .withSpawnEntityLiving(armorStandEntityId, EntityType.ARMOR_STAND, offsetPosition(position), armorStandDataWatcher)
                 .withSpawnEntityLivingOrObject(entityId, content, position)
                 .withTeleportEntity(entityId, position)
-                .withPassenger(armorStandEntityId, entityId)
+                .attachEntity(entityId, armorStandEntityId)
                 .sendTo(player);
     }
 
@@ -50,11 +50,11 @@ class EntityHologramRenderer implements NmsEntityHologramRenderer {
         DecentPosition position = data.getPosition();
         EntityType content = data.getContent();
         EntityPacketsBuilder.create()
-                .withRemovePassenger(armorStandEntityId)
+                .unattachEntity(entityId)
                 .withRemoveEntity(oldEntityId)
                 .withSpawnEntityLivingOrObject(entityId, content, position)
                 .withTeleportEntity(entityId, position)
-                .withPassenger(armorStandEntityId, entityId)
+                .attachEntity(entityId, armorStandEntityId)
                 .sendTo(player);
     }
 
@@ -70,7 +70,7 @@ class EntityHologramRenderer implements NmsEntityHologramRenderer {
     @Override
     public synchronized void hide(Player player) {
         EntityPacketsBuilder.create()
-                .withRemovePassenger(armorStandEntityId)
+                .unattachEntity(entityId)
                 .withRemoveEntity(entityId)
                 .withRemoveEntity(armorStandEntityId)
                 .sendTo(player);

--- a/nms/nms-v1_8_R1/src/main/java/eu/decentsoftware/holograms/nms/v1_8_R1/EntityPacketsBuilder.java
+++ b/nms/nms-v1_8_R1/src/main/java/eu/decentsoftware/holograms/nms/v1_8_R1/EntityPacketsBuilder.java
@@ -143,18 +143,18 @@ class EntityPacketsBuilder {
         return this;
     }
 
-    EntityPacketsBuilder withPassenger(int entityId, int passenger) {
-        return updatePassenger(entityId, passenger);
+    EntityPacketsBuilder attachEntity(int attachedEntityId, int vehicleEntityId) {
+        return updatePassenger(attachedEntityId, vehicleEntityId);
     }
 
-    EntityPacketsBuilder withRemovePassenger(int entityId) {
-        return updatePassenger(entityId, -1);
+    EntityPacketsBuilder unattachEntity(int attachedEntityId) {
+        return updatePassenger(attachedEntityId, -1);
     }
 
-    private EntityPacketsBuilder updatePassenger(int entityId, int passenger) {
+    private EntityPacketsBuilder updatePassenger(int attachedEntityId, int vehicleEntityId) {
         PacketDataSerializerWrapper serializer = PacketDataSerializerWrapper.getInstance();
-        serializer.writeInt(passenger);
-        serializer.writeInt(entityId);
+        serializer.writeInt(attachedEntityId);
+        serializer.writeInt(vehicleEntityId);
         serializer.writeByte(0); // Leash
 
         PacketPlayOutAttachEntity packet = new PacketPlayOutAttachEntity();

--- a/nms/nms-v1_8_R1/src/main/java/eu/decentsoftware/holograms/nms/v1_8_R1/IconHologramRenderer.java
+++ b/nms/nms-v1_8_R1/src/main/java/eu/decentsoftware/holograms/nms/v1_8_R1/IconHologramRenderer.java
@@ -34,7 +34,7 @@ class IconHologramRenderer implements NmsIconHologramRenderer {
                         .withItemStack(content)
                         .toWatchableObjects())
                 .withTeleportEntity(itemEntityId, position)
-                .withPassenger(armorStandEntityId, itemEntityId)
+                .attachEntity(itemEntityId, armorStandEntityId)
                 .sendTo(player);
     }
 
@@ -57,7 +57,7 @@ class IconHologramRenderer implements NmsIconHologramRenderer {
     @Override
     public void hide(Player player) {
         EntityPacketsBuilder.create()
-                .withRemovePassenger(armorStandEntityId)
+                .unattachEntity(itemEntityId)
                 .withRemoveEntity(itemEntityId)
                 .withRemoveEntity(armorStandEntityId)
                 .sendTo(player);

--- a/nms/nms-v1_8_R2/src/main/java/eu/decentsoftware/holograms/nms/v1_8_R2/EntityHologramRenderer.java
+++ b/nms/nms-v1_8_R2/src/main/java/eu/decentsoftware/holograms/nms/v1_8_R2/EntityHologramRenderer.java
@@ -30,7 +30,7 @@ class EntityHologramRenderer implements NmsEntityHologramRenderer {
                 .withSpawnEntityLiving(armorStandEntityId, EntityType.ARMOR_STAND, offsetPosition(position), armorStandDataWatcher)
                 .withSpawnEntityLivingOrObject(entityId, content, position)
                 .withTeleportEntity(entityId, position)
-                .withPassenger(armorStandEntityId, entityId)
+                .attachEntity(entityId, armorStandEntityId)
                 .sendTo(player);
     }
 
@@ -39,11 +39,11 @@ class EntityHologramRenderer implements NmsEntityHologramRenderer {
         DecentPosition position = data.getPosition();
         EntityType content = data.getContent();
         EntityPacketsBuilder.create()
-                .withRemovePassenger(armorStandEntityId)
+                .unattachEntity(entityId)
                 .withRemoveEntity(entityId)
                 .withSpawnEntityLivingOrObject(entityId, content, position)
                 .withTeleportEntity(entityId, position)
-                .withPassenger(armorStandEntityId, entityId)
+                .attachEntity(entityId, armorStandEntityId)
                 .sendTo(player);
     }
 
@@ -59,7 +59,7 @@ class EntityHologramRenderer implements NmsEntityHologramRenderer {
     @Override
     public void hide(Player player) {
         EntityPacketsBuilder.create()
-                .withRemovePassenger(armorStandEntityId)
+                .unattachEntity(entityId)
                 .withRemoveEntity(entityId)
                 .withRemoveEntity(armorStandEntityId)
                 .sendTo(player);

--- a/nms/nms-v1_8_R2/src/main/java/eu/decentsoftware/holograms/nms/v1_8_R2/EntityPacketsBuilder.java
+++ b/nms/nms-v1_8_R2/src/main/java/eu/decentsoftware/holograms/nms/v1_8_R2/EntityPacketsBuilder.java
@@ -142,18 +142,18 @@ class EntityPacketsBuilder {
         return this;
     }
 
-    EntityPacketsBuilder withPassenger(int entityId, int passenger) {
-        return updatePassenger(entityId, passenger);
+    EntityPacketsBuilder attachEntity(int attachedEntityId, int vehicleEntityId) {
+        return updatePassenger(attachedEntityId, vehicleEntityId);
     }
 
-    EntityPacketsBuilder withRemovePassenger(int entityId) {
-        return updatePassenger(entityId, -1);
+    EntityPacketsBuilder unattachEntity(int attachedEntityId) {
+        return updatePassenger(attachedEntityId, -1);
     }
 
-    private EntityPacketsBuilder updatePassenger(int entityId, int passenger) {
+    private EntityPacketsBuilder updatePassenger(int attachedEntityId, int vehicleEntityId) {
         PacketDataSerializerWrapper serializer = PacketDataSerializerWrapper.getInstance();
-        serializer.writeInt(passenger);
-        serializer.writeInt(entityId);
+        serializer.writeInt(attachedEntityId);
+        serializer.writeInt(vehicleEntityId);
         serializer.writeByte(0); // Leash
 
         PacketPlayOutAttachEntity packet = new PacketPlayOutAttachEntity();

--- a/nms/nms-v1_8_R2/src/main/java/eu/decentsoftware/holograms/nms/v1_8_R2/IconHologramRenderer.java
+++ b/nms/nms-v1_8_R2/src/main/java/eu/decentsoftware/holograms/nms/v1_8_R2/IconHologramRenderer.java
@@ -34,7 +34,7 @@ class IconHologramRenderer implements NmsIconHologramRenderer {
                         .withItemStack(content)
                         .toWatchableObjects())
                 .withTeleportEntity(itemEntityId, position)
-                .withPassenger(armorStandEntityId, itemEntityId)
+                .attachEntity(itemEntityId, armorStandEntityId)
                 .sendTo(player);
     }
 
@@ -57,7 +57,7 @@ class IconHologramRenderer implements NmsIconHologramRenderer {
     @Override
     public void hide(Player player) {
         EntityPacketsBuilder.create()
-                .withRemovePassenger(armorStandEntityId)
+                .unattachEntity(itemEntityId)
                 .withRemoveEntity(itemEntityId)
                 .withRemoveEntity(armorStandEntityId)
                 .sendTo(player);

--- a/nms/nms-v1_8_R3/src/main/java/eu/decentsoftware/holograms/nms/v1_8_R3/EntityHologramRenderer.java
+++ b/nms/nms-v1_8_R3/src/main/java/eu/decentsoftware/holograms/nms/v1_8_R3/EntityHologramRenderer.java
@@ -30,7 +30,7 @@ class EntityHologramRenderer implements NmsEntityHologramRenderer {
                 .withSpawnEntityLiving(armorStandEntityId, EntityType.ARMOR_STAND, offsetPosition(position), armorStandDataWatcher)
                 .withSpawnEntityLivingOrObject(entityId, content, position)
                 .withTeleportEntity(entityId, position)
-                .withPassenger(armorStandEntityId, entityId)
+                .attachEntity(entityId, armorStandEntityId)
                 .sendTo(player);
     }
 
@@ -39,11 +39,11 @@ class EntityHologramRenderer implements NmsEntityHologramRenderer {
         DecentPosition position = data.getPosition();
         EntityType content = data.getContent();
         EntityPacketsBuilder.create()
-                .withRemovePassenger(armorStandEntityId)
+                .unattachEntity(entityId)
                 .withRemoveEntity(entityId)
                 .withSpawnEntityLivingOrObject(entityId, content, position)
                 .withTeleportEntity(entityId, position)
-                .withPassenger(armorStandEntityId, entityId)
+                .attachEntity(entityId, armorStandEntityId)
                 .sendTo(player);
     }
 
@@ -59,7 +59,7 @@ class EntityHologramRenderer implements NmsEntityHologramRenderer {
     @Override
     public void hide(Player player) {
         EntityPacketsBuilder.create()
-                .withRemovePassenger(armorStandEntityId)
+                .unattachEntity(entityId)
                 .withRemoveEntity(entityId)
                 .withRemoveEntity(armorStandEntityId)
                 .sendTo(player);

--- a/nms/nms-v1_8_R3/src/main/java/eu/decentsoftware/holograms/nms/v1_8_R3/EntityPacketsBuilder.java
+++ b/nms/nms-v1_8_R3/src/main/java/eu/decentsoftware/holograms/nms/v1_8_R3/EntityPacketsBuilder.java
@@ -142,18 +142,18 @@ class EntityPacketsBuilder {
         return this;
     }
 
-    EntityPacketsBuilder withPassenger(int entityId, int passenger) {
-        return updatePassenger(entityId, passenger);
+    EntityPacketsBuilder attachEntity(int attachedEntityId, int vehicleEntityId) {
+        return updatePassenger(attachedEntityId, vehicleEntityId);
     }
 
-    EntityPacketsBuilder withRemovePassenger(int entityId) {
-        return updatePassenger(entityId, -1);
+    EntityPacketsBuilder unattachEntity(int attachedEntityId) {
+        return updatePassenger(attachedEntityId, -1);
     }
 
-    private EntityPacketsBuilder updatePassenger(int entityId, int passenger) {
+    private EntityPacketsBuilder updatePassenger(int attachedEntityId, int vehicleEntityId) {
         PacketDataSerializerWrapper serializer = PacketDataSerializerWrapper.getInstance();
-        serializer.writeInt(passenger);
-        serializer.writeInt(entityId);
+        serializer.writeInt(attachedEntityId);
+        serializer.writeInt(vehicleEntityId);
         serializer.writeByte(0); // Leash
 
         PacketPlayOutAttachEntity packet = new PacketPlayOutAttachEntity();

--- a/nms/nms-v1_8_R3/src/main/java/eu/decentsoftware/holograms/nms/v1_8_R3/IconHologramRenderer.java
+++ b/nms/nms-v1_8_R3/src/main/java/eu/decentsoftware/holograms/nms/v1_8_R3/IconHologramRenderer.java
@@ -34,7 +34,7 @@ class IconHologramRenderer implements NmsIconHologramRenderer {
                         .withItemStack(content)
                         .toWatchableObjects())
                 .withTeleportEntity(itemEntityId, position)
-                .withPassenger(armorStandEntityId, itemEntityId)
+                .attachEntity(itemEntityId, armorStandEntityId)
                 .sendTo(player);
     }
 
@@ -57,7 +57,7 @@ class IconHologramRenderer implements NmsIconHologramRenderer {
     @Override
     public void hide(Player player) {
         EntityPacketsBuilder.create()
-                .withRemovePassenger(armorStandEntityId)
+                .unattachEntity(itemEntityId)
                 .withRemoveEntity(itemEntityId)
                 .withRemoveEntity(armorStandEntityId)
                 .sendTo(player);


### PR DESCRIPTION
On 1.8, it's the vehicle entity id that has to be `-1` to unattach the passenger. Previously, we sent the passenger entity id as `-1` which is wrong.

See: https://minecraft.wiki/w/Protocol?oldid=2772100#Attach_Entity