### PR TITLE
Send at least one property in entity data watcher

### DIFF
--- a/nms/nms-v1_8_R1/src/main/java/eu/decentsoftware/holograms/nms/v1_8_R1/DataWatcherBuilder.java
+++ b/nms/nms-v1_8_R1/src/main/java/eu/decentsoftware/holograms/nms/v1_8_R1/DataWatcherBuilder.java
@@ -3,55 +3,60 @@ package eu.decentsoftware.holograms.nms.v1_8_R1;
 import net.minecraft.server.v1_8_R1.DataWatcher;
 
 class DataWatcherBuilder {
- 
-     private final DataWatcher dataWatcher;
- 
-     private DataWatcherBuilder() {
-         this.dataWatcher = new DataWatcher(null);
-     }
- 
-     DataWatcher toDataWatcher() {
-         return dataWatcher;
-     }
- 
-     DataWatcherBuilder withInvisible() {
-         /*
-          * Entity Properties:
-          * 0x01 - On Fire
-          * 0x02 - Crouched
-          * 0x08 - Sprinting
-          * 0x10 - Eating/Drinking/Blocking
-          * 0x20 - Invisible
-          */
- 
-         EntityMetadataType.ENTITY_PROPERTIES.addToDataWatcher(dataWatcher, (byte) 0x20);
-         return this;
-     }
- 
-     DataWatcherBuilder withArmorStandProperties(boolean small, boolean marker) {
-         /*
-          * Armor Stand Properties:
-          * 0x01 - Small
-          * 0x02 - Has Gravity
-          * 0x04 - Has Arms
-          * 0x08 - Remove Baseplate
-          * 0x10 - Marker (Zero bounding box)
-          */
- 
-         byte data = 0x08; // Always Remove Baseplate
-         if (small) {
-             data |= 0x01;
-         }
-         if (marker) {
-             data |= 0x10;
-         }
- 
-         EntityMetadataType.ARMOR_STAND_PROPERTIES.addToDataWatcher(dataWatcher, data);
-         return this;
-     }
- 
-     static DataWatcherBuilder create() {
-         return new DataWatcherBuilder();
-     }
- 
- }
+
+    private final DataWatcher dataWatcher;
+
+    private DataWatcherBuilder() {
+        this.dataWatcher = new DataWatcher(null);
+    }
+
+    DataWatcher toDataWatcher() {
+        return dataWatcher;
+    }
+
+    DataWatcherBuilder withInvisible() {
+        /*
+         * Entity Properties:
+         * 0x01 - On Fire
+         * 0x02 - Crouched
+         * 0x08 - Sprinting
+         * 0x10 - Eating/Drinking/Blocking
+         * 0x20 - Invisible
+         */
+
+        EntityMetadataType.ENTITY_PROPERTIES.addToDataWatcher(dataWatcher, (byte) 0x20);
+        return this;
+    }
+
+    DataWatcherBuilder withEmptyEntityProperties() {
+        EntityMetadataType.ENTITY_PROPERTIES.addToDataWatcher(dataWatcher, (byte) 0x00);
+        return this;
+    }
+
+    DataWatcherBuilder withArmorStandProperties(boolean small, boolean marker) {
+        /*
+         * Armor Stand Properties:
+         * 0x01 - Small
+         * 0x02 - Has Gravity
+         * 0x04 - Has Arms
+         * 0x08 - Remove Baseplate
+         * 0x10 - Marker (Zero bounding box)
+         */
+
+        byte data = 0x08; // Always Remove Baseplate
+        if (small) {
+            data |= 0x01;
+        }
+        if (marker) {
+            data |= 0x10;
+        }
+
+        EntityMetadataType.ARMOR_STAND_PROPERTIES.addToDataWatcher(dataWatcher, data);
+        return this;
+    }
+
+    static DataWatcherBuilder create() {
+        return new DataWatcherBuilder();
+    }
+
+}

--- a/nms/nms-v1_8_R1/src/main/java/eu/decentsoftware/holograms/nms/v1_8_R1/EntityPacketsBuilder.java
+++ b/nms/nms-v1_8_R1/src/main/java/eu/decentsoftware/holograms/nms/v1_8_R1/EntityPacketsBuilder.java
@@ -30,9 +30,13 @@ class EntityPacketsBuilder {
     private static final ReflectField<DataWatcher> SPAWN_ENTITY_LIVING_PACKET_DATA_WATCHER_FIELD = new ReflectField<>(
             PacketPlayOutSpawnEntityLiving.class, "l");
     private final List<Packet> packets;
+    private final DataWatcher emptyDataWatcher;
 
     private EntityPacketsBuilder() {
         this.packets = new ArrayList<>();
+        this.emptyDataWatcher = DataWatcherBuilder.create()
+                .withEmptyEntityProperties()
+                .toDataWatcher();
     }
 
     void sendTo(Player player) {
@@ -64,7 +68,7 @@ class EntityPacketsBuilder {
     }
 
     EntityPacketsBuilder withSpawnEntityLiving(int entityId, EntityType type, DecentPosition position) {
-        return withSpawnEntityLiving(entityId, type, position, new DataWatcher(null));
+        return withSpawnEntityLiving(entityId, type, position, emptyDataWatcher);
     }
 
     EntityPacketsBuilder withSpawnEntityLiving(int entityId, EntityType type, DecentPosition position, DataWatcher dataWatcher) {

--- a/nms/nms-v1_8_R2/src/main/java/eu/decentsoftware/holograms/nms/v1_8_R2/DataWatcherBuilder.java
+++ b/nms/nms-v1_8_R2/src/main/java/eu/decentsoftware/holograms/nms/v1_8_R2/DataWatcherBuilder.java
@@ -3,55 +3,60 @@ package eu.decentsoftware.holograms.nms.v1_8_R2;
 import net.minecraft.server.v1_8_R2.DataWatcher;
 
 class DataWatcherBuilder {
- 
-     private final DataWatcher dataWatcher;
- 
-     private DataWatcherBuilder() {
-         this.dataWatcher = new DataWatcher(null);
-     }
- 
-     DataWatcher toDataWatcher() {
-         return dataWatcher;
-     }
- 
-     DataWatcherBuilder withInvisible() {
-         /*
-          * Entity Properties:
-          * 0x01 - On Fire
-          * 0x02 - Crouched
-          * 0x08 - Sprinting
-          * 0x10 - Eating/Drinking/Blocking
-          * 0x20 - Invisible
-          */
- 
-         EntityMetadataType.ENTITY_PROPERTIES.addToDataWatcher(dataWatcher, (byte) 0x20);
-         return this;
-     }
- 
-     DataWatcherBuilder withArmorStandProperties(boolean small, boolean marker) {
-         /*
-          * Armor Stand Properties:
-          * 0x01 - Small
-          * 0x02 - Has Gravity
-          * 0x04 - Has Arms
-          * 0x08 - Remove Baseplate
-          * 0x10 - Marker (Zero bounding box)
-          */
- 
-         byte data = 0x08; // Always Remove Baseplate
-         if (small) {
-             data |= 0x01;
-         }
-         if (marker) {
-             data |= 0x10;
-         }
- 
-         EntityMetadataType.ARMOR_STAND_PROPERTIES.addToDataWatcher(dataWatcher, data);
-         return this;
-     }
- 
-     static DataWatcherBuilder create() {
-         return new DataWatcherBuilder();
-     }
- 
- }
+
+    private final DataWatcher dataWatcher;
+
+    private DataWatcherBuilder() {
+        this.dataWatcher = new DataWatcher(null);
+    }
+
+    DataWatcher toDataWatcher() {
+        return dataWatcher;
+    }
+
+    DataWatcherBuilder withInvisible() {
+        /*
+         * Entity Properties:
+         * 0x01 - On Fire
+         * 0x02 - Crouched
+         * 0x08 - Sprinting
+         * 0x10 - Eating/Drinking/Blocking
+         * 0x20 - Invisible
+         */
+
+        EntityMetadataType.ENTITY_PROPERTIES.addToDataWatcher(dataWatcher, (byte) 0x20);
+        return this;
+    }
+
+    DataWatcherBuilder withEmptyEntityProperties() {
+        EntityMetadataType.ENTITY_PROPERTIES.addToDataWatcher(dataWatcher, (byte) 0x00);
+        return this;
+    }
+
+    DataWatcherBuilder withArmorStandProperties(boolean small, boolean marker) {
+        /*
+         * Armor Stand Properties:
+         * 0x01 - Small
+         * 0x02 - Has Gravity
+         * 0x04 - Has Arms
+         * 0x08 - Remove Baseplate
+         * 0x10 - Marker (Zero bounding box)
+         */
+
+        byte data = 0x08; // Always Remove Baseplate
+        if (small) {
+            data |= 0x01;
+        }
+        if (marker) {
+            data |= 0x10;
+        }
+
+        EntityMetadataType.ARMOR_STAND_PROPERTIES.addToDataWatcher(dataWatcher, data);
+        return this;
+    }
+
+    static DataWatcherBuilder create() {
+        return new DataWatcherBuilder();
+    }
+
+}

--- a/nms/nms-v1_8_R2/src/main/java/eu/decentsoftware/holograms/nms/v1_8_R2/EntityPacketsBuilder.java
+++ b/nms/nms-v1_8_R2/src/main/java/eu/decentsoftware/holograms/nms/v1_8_R2/EntityPacketsBuilder.java
@@ -29,9 +29,13 @@ class EntityPacketsBuilder {
     private static final ReflectField<DataWatcher> SPAWN_ENTITY_LIVING_PACKET_DATA_WATCHER_FIELD = new ReflectField<>(
             PacketPlayOutSpawnEntityLiving.class, "l");
     private final List<Packet<?>> packets;
+    private final DataWatcher emptyDataWatcher;
 
     private EntityPacketsBuilder() {
         this.packets = new ArrayList<>();
+        this.emptyDataWatcher = DataWatcherBuilder.create()
+                .withEmptyEntityProperties()
+                .toDataWatcher();
     }
 
     void sendTo(Player player) {
@@ -63,7 +67,7 @@ class EntityPacketsBuilder {
     }
 
     EntityPacketsBuilder withSpawnEntityLiving(int entityId, EntityType type, DecentPosition position) {
-        return withSpawnEntityLiving(entityId, type, position, new DataWatcher(null));
+        return withSpawnEntityLiving(entityId, type, position, emptyDataWatcher);
     }
 
     EntityPacketsBuilder withSpawnEntityLiving(int entityId, EntityType type, DecentPosition position, DataWatcher dataWatcher) {

--- a/nms/nms-v1_8_R3/src/main/java/eu/decentsoftware/holograms/nms/v1_8_R3/DataWatcherBuilder.java
+++ b/nms/nms-v1_8_R3/src/main/java/eu/decentsoftware/holograms/nms/v1_8_R3/DataWatcherBuilder.java
@@ -28,6 +28,11 @@ class DataWatcherBuilder {
         return this;
     }
 
+    DataWatcherBuilder withEmptyEntityProperties() {
+        EntityMetadataType.ENTITY_PROPERTIES.addToDataWatcher(dataWatcher, (byte) 0x00);
+        return this;
+    }
+
     DataWatcherBuilder withArmorStandProperties(boolean small, boolean marker) {
         /*
          * Armor Stand Properties:

--- a/nms/nms-v1_8_R3/src/main/java/eu/decentsoftware/holograms/nms/v1_8_R3/EntityPacketsBuilder.java
+++ b/nms/nms-v1_8_R3/src/main/java/eu/decentsoftware/holograms/nms/v1_8_R3/EntityPacketsBuilder.java
@@ -29,9 +29,13 @@ class EntityPacketsBuilder {
     private static final ReflectField<DataWatcher> SPAWN_ENTITY_LIVING_PACKET_DATA_WATCHER_FIELD = new ReflectField<>(
             PacketPlayOutSpawnEntityLiving.class, "l");
     private final List<Packet<?>> packets;
+    private final DataWatcher emptyDataWatcher;
 
     private EntityPacketsBuilder() {
         this.packets = new ArrayList<>();
+        this.emptyDataWatcher = DataWatcherBuilder.create()
+                .withEmptyEntityProperties()
+                .toDataWatcher();
     }
 
     void sendTo(Player player) {
@@ -63,7 +67,7 @@ class EntityPacketsBuilder {
     }
 
     EntityPacketsBuilder withSpawnEntityLiving(int entityId, EntityType type, DecentPosition position) {
-        return withSpawnEntityLiving(entityId, type, position, new DataWatcher(null));
+        return withSpawnEntityLiving(entityId, type, position, emptyDataWatcher);
     }
 
     EntityPacketsBuilder withSpawnEntityLiving(int entityId, EntityType type, DecentPosition position, DataWatcher dataWatcher) {


### PR DESCRIPTION
We should send at least one entity metadata property to the client. Some clients throw an NPE when there are no metadata properties in the Spawn Entity Living packet. 