### PR TITLE
Update to 1.21.9 and split NMS for Spigot and Paper

### DIFF
--- a/nms/nms-paper_v1_21_R6/build.gradle
+++ b/nms/nms-paper_v1_21_R6/build.gradle
@@ -1,0 +1,18 @@
+plugins {
+    id("io.papermc.paperweight.userdev") version "2.0.0-beta.18"
+}
+
+dependencies {
+    paperweight.paperDevBundle("1.21.9-R0.1-SNAPSHOT")
+}
+
+compileJava {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}

--- a/nms/nms-paper_v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/paper_v1_21_R6/ClickableHologramRenderer.java
+++ b/nms/nms-paper_v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/paper_v1_21_R6/ClickableHologramRenderer.java
@@ -1,0 +1,46 @@
+package eu.decentsoftware.holograms.nms.paper_v1_21_R6;
+
+import eu.decentsoftware.holograms.nms.api.renderer.NmsClickableHologramRenderer;
+import eu.decentsoftware.holograms.shared.DecentPosition;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+
+class ClickableHologramRenderer implements NmsClickableHologramRenderer {
+
+    private final int entityId;
+
+    ClickableHologramRenderer(EntityIdGenerator entityIdGenerator) {
+        this.entityId = entityIdGenerator.getFreeEntityId();
+    }
+
+    @Override
+    public void display(Player player, DecentPosition position) {
+        EntityPacketsBuilder.create()
+                .withSpawnEntity(entityId, EntityType.ARMOR_STAND, position)
+                .withEntityMetadata(entityId, EntityMetadataBuilder.create()
+                        .withInvisible()
+                        .withNoGravity()
+                        .withArmorStandProperties(false, false)
+                        .toWatchableObjects())
+                .sendTo(player);
+    }
+
+    @Override
+    public void move(Player player, DecentPosition position) {
+        EntityPacketsBuilder.create()
+                .withTeleportEntity(entityId, position)
+                .sendTo(player);
+    }
+
+    @Override
+    public void hide(Player player) {
+        EntityPacketsBuilder.create()
+                .withRemoveEntity(entityId)
+                .sendTo(player);
+    }
+
+    @Override
+    public int getEntityId() {
+        return entityId;
+    }
+}

--- a/nms/nms-paper_v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/paper_v1_21_R6/EntityHologramRenderer.java
+++ b/nms/nms-paper_v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/paper_v1_21_R6/EntityHologramRenderer.java
@@ -1,0 +1,63 @@
+package eu.decentsoftware.holograms.nms.paper_v1_21_R6;
+
+import eu.decentsoftware.holograms.nms.api.NmsHologramPartData;
+import eu.decentsoftware.holograms.nms.api.renderer.NmsEntityHologramRenderer;
+import eu.decentsoftware.holograms.shared.DecentPosition;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+
+class EntityHologramRenderer implements NmsEntityHologramRenderer {
+
+    private final int entityId;
+
+    EntityHologramRenderer(EntityIdGenerator entityIdGenerator) {
+        this.entityId = entityIdGenerator.getFreeEntityId();
+    }
+
+    @Override
+    public void display(Player player, NmsHologramPartData<EntityType> data) {
+        DecentPosition position = data.getPosition();
+        EntityType content = data.getContent();
+        DecentPosition offsetPosition = offsetPosition(position);
+        EntityPacketsBuilder.create()
+                .withSpawnEntity(entityId, content, offsetPosition)
+                .withEntityMetadata(entityId, EntityMetadataBuilder.create()
+                        .withSilent()
+                        .withNoGravity()
+                        .toWatchableObjects())
+                .sendTo(player);
+    }
+
+    @Override
+    public void updateContent(Player player, NmsHologramPartData<EntityType> data) {
+        hide(player);
+        display(player, data);
+    }
+
+    @Override
+    public void move(Player player, NmsHologramPartData<EntityType> data) {
+        hide(player);
+        display(player, data);
+    }
+
+    @Override
+    public void hide(Player player) {
+        EntityPacketsBuilder.create()
+                .withRemoveEntity(entityId)
+                .sendTo(player);
+    }
+
+    @Override
+    public double getHeight(NmsHologramPartData<EntityType> data) {
+        return EntityTypeRegistry.getEntityTypeHeight(data.getContent());
+    }
+
+    @Override
+    public int[] getEntityIds() {
+        return new int[]{entityId};
+    }
+
+    private DecentPosition offsetPosition(DecentPosition position) {
+        return position.subtractY(0.25d);
+    }
+}

--- a/nms/nms-paper_v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/paper_v1_21_R6/EntityIdGenerator.java
+++ b/nms/nms-paper_v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/paper_v1_21_R6/EntityIdGenerator.java
@@ -1,0 +1,26 @@
+package eu.decentsoftware.holograms.nms.paper_v1_21_R6;
+
+import eu.decentsoftware.holograms.nms.api.DecentHologramsNmsException;
+import eu.decentsoftware.holograms.shared.reflect.ReflectField;
+import net.minecraft.world.entity.Entity;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+class EntityIdGenerator {
+
+    private static final ReflectField<AtomicInteger> ENTITY_COUNT_FIELD = new ReflectField<>(Entity.class,"ENTITY_COUNTER");
+
+    int getFreeEntityId() {
+        try {
+            /*
+             * We are getting the new entity ids the same way as the server does. This is to ensure
+             * that the ids are unique and don't conflict with any other entities.
+             */
+            AtomicInteger entityCount = ENTITY_COUNT_FIELD.get(null);
+            return entityCount.incrementAndGet();
+        } catch (Exception e) {
+            throw new DecentHologramsNmsException("Failed to get new entity ID", e);
+        }
+    }
+
+}

--- a/nms/nms-paper_v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/paper_v1_21_R6/EntityMetadataBuilder.java
+++ b/nms/nms-paper_v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/paper_v1_21_R6/EntityMetadataBuilder.java
@@ -1,0 +1,92 @@
+package eu.decentsoftware.holograms.nms.paper_v1_21_R6;
+
+import com.google.common.base.Strings;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.syncher.SynchedEntityData;
+import org.bukkit.craftbukkit.inventory.CraftItemStack;
+import org.bukkit.craftbukkit.util.CraftChatMessage;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+class EntityMetadataBuilder {
+
+    private final List<SynchedEntityData.DataItem<?>> watchableObjects;
+
+    private EntityMetadataBuilder() {
+        this.watchableObjects = new ArrayList<>();
+    }
+
+    List<SynchedEntityData.DataItem<?>> toWatchableObjects() {
+        return watchableObjects;
+    }
+
+    EntityMetadataBuilder withInvisible() {
+        /*
+         * Entity Properties:
+         * 0x01 - On Fire
+         * 0x02 - Crouched
+         * 0x08 - Sprinting
+         * 0x10 - Swimming
+         * 0x20 - Invisible
+         * 0x40 - Has glowing effect
+         * 0x80 - If flying with an elytra
+         */
+
+        watchableObjects.add(EntityMetadataType.ENTITY_PROPERTIES.construct((byte) 0x20));
+        return this;
+    }
+
+    EntityMetadataBuilder withArmorStandProperties(boolean small, boolean marker) {
+        /*
+         * Armor Stand Properties:
+         * 0x01 - Small
+         * 0x02 - Unused
+         * 0x04 - Has Arms
+         * 0x08 - Remove Baseplate
+         * 0x10 - Marker (Zero bounding box)
+         */
+
+        byte data = 0x08; // Always Remove Baseplate
+        if (small) {
+            data |= 0x01;
+        }
+        if (marker) {
+            data |= 0x10;
+        }
+
+        watchableObjects.add(EntityMetadataType.ARMOR_STAND_PROPERTIES.construct(data));
+        return this;
+    }
+
+    EntityMetadataBuilder withCustomName(String customName) {
+        Component Component = CraftChatMessage.fromStringOrNull(customName);
+        Optional<Component> optionalComponent = Optional.ofNullable(Component);
+        watchableObjects.add(EntityMetadataType.ENTITY_CUSTOM_NAME.construct(optionalComponent));
+        boolean visible = !Strings.isNullOrEmpty(customName);
+        watchableObjects.add(EntityMetadataType.ENTITY_CUSTOM_NAME_VISIBLE.construct(visible));
+        return this;
+    }
+
+    EntityMetadataBuilder withItemStack(ItemStack itemStack) {
+        watchableObjects.add(EntityMetadataType.ITEM_STACK.construct(CraftItemStack.asNMSCopy(itemStack)));
+        return this;
+    }
+
+    EntityMetadataBuilder withSilent() {
+        watchableObjects.add(EntityMetadataType.ENTITY_SILENT.construct(true));
+        return this;
+    }
+
+    EntityMetadataBuilder withNoGravity() {
+        watchableObjects.add(EntityMetadataType.ENTITY_HAS_NO_GRAVITY.construct(true));
+        return this;
+    }
+
+    static EntityMetadataBuilder create() {
+        return new EntityMetadataBuilder();
+    }
+
+}

--- a/nms/nms-paper_v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/paper_v1_21_R6/EntityMetadataType.java
+++ b/nms/nms-paper_v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/paper_v1_21_R6/EntityMetadataType.java
@@ -1,0 +1,49 @@
+package eu.decentsoftware.holograms.nms.paper_v1_21_R6;
+
+import eu.decentsoftware.holograms.shared.reflect.ReflectUtil;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.syncher.EntityDataAccessor;
+import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.decoration.ArmorStand;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.Optional;
+
+class EntityMetadataType<T> {
+
+    private static final EntityDataAccessor<Byte> ENTITY_PROPERTIES_OBJECT
+            = ReflectUtil.getFieldValue(Entity.class, "DATA_SHARED_FLAGS_ID");
+    private static final EntityDataAccessor<Optional<Component>> ENTITY_CUSTOM_NAME_OBJECT
+            = ReflectUtil.getFieldValue(Entity.class, "DATA_CUSTOM_NAME");
+    private static final EntityDataAccessor<Boolean> ENTITY_CUSTOM_NAME_VISIBLE_OBJECT
+            = ReflectUtil.getFieldValue(Entity.class, "DATA_CUSTOM_NAME_VISIBLE");
+    private static final EntityDataAccessor<Boolean> ENTITY_SILENT_OBJECT
+            = ReflectUtil.getFieldValue(Entity.class, "DATA_SILENT");
+    private static final EntityDataAccessor<Boolean> ENTITY_HAS_NO_GRAVITY_OBJECT
+            = ReflectUtil.getFieldValue(Entity.class, "DATA_NO_GRAVITY");
+    private static final EntityDataAccessor<Byte> ARMOR_STAND_PROPERTIES_OBJECT
+            = ReflectUtil.getFieldValue(ArmorStand.class, "DATA_CLIENT_FLAGS");
+    private static final EntityDataAccessor<ItemStack> ITEM_STACK_OBJECT
+            = ReflectUtil.getFieldValue(ItemEntity.class, "DATA_ITEM");
+
+    static final EntityMetadataType<Byte> ENTITY_PROPERTIES = new EntityMetadataType<>(ENTITY_PROPERTIES_OBJECT);
+    static final EntityMetadataType<Optional<Component>> ENTITY_CUSTOM_NAME = new EntityMetadataType<>(ENTITY_CUSTOM_NAME_OBJECT);
+    static final EntityMetadataType<Boolean> ENTITY_CUSTOM_NAME_VISIBLE = new EntityMetadataType<>(ENTITY_CUSTOM_NAME_VISIBLE_OBJECT);
+    static final EntityMetadataType<Boolean> ENTITY_SILENT = new EntityMetadataType<>(ENTITY_SILENT_OBJECT);
+    static final EntityMetadataType<Boolean> ENTITY_HAS_NO_GRAVITY = new EntityMetadataType<>(ENTITY_HAS_NO_GRAVITY_OBJECT);
+    static final EntityMetadataType<Byte> ARMOR_STAND_PROPERTIES = new EntityMetadataType<>(ARMOR_STAND_PROPERTIES_OBJECT);
+    static final EntityMetadataType<ItemStack> ITEM_STACK = new EntityMetadataType<>(ITEM_STACK_OBJECT);
+
+    private final EntityDataAccessor<T> EntityDataAccessor;
+
+    private EntityMetadataType(EntityDataAccessor<T> EntityDataAccessor) {
+        this.EntityDataAccessor = EntityDataAccessor;
+    }
+
+    SynchedEntityData.DataItem<T> construct(T value) {
+        return new SynchedEntityData.DataItem<>(EntityDataAccessor, value);
+    }
+
+}

--- a/nms/nms-paper_v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/paper_v1_21_R6/EntityPacketsBuilder.java
+++ b/nms/nms-paper_v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/paper_v1_21_R6/EntityPacketsBuilder.java
@@ -1,0 +1,135 @@
+package eu.decentsoftware.holograms.nms.paper_v1_21_R6;
+
+import com.mojang.datafixers.util.Pair;
+import eu.decentsoftware.holograms.shared.DecentPosition;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ClientboundRemoveEntitiesPacket;
+import net.minecraft.network.protocol.game.ClientboundSetEquipmentPacket;
+import net.minecraft.network.protocol.game.ClientboundSetEntityDataPacket;
+import net.minecraft.network.protocol.game.ClientboundTeleportEntityPacket;
+import net.minecraft.network.protocol.game.ClientboundSetPassengersPacket;
+import net.minecraft.network.protocol.game.ClientboundAddEntityPacket;
+import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.world.entity.PositionMoveRotation;
+import net.minecraft.world.phys.Vec3;
+import org.bukkit.craftbukkit.CraftEquipmentSlot;
+import org.bukkit.craftbukkit.entity.CraftPlayer;
+import org.bukkit.craftbukkit.inventory.CraftItemStack;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+class EntityPacketsBuilder {
+
+    private final List<Packet<?>> packets;
+
+    private EntityPacketsBuilder() {
+        this.packets = new ArrayList<>();
+    }
+
+    void sendTo(Player player) {
+        for (Packet<?> packet : packets) {
+            sendPacket(player, packet);
+        }
+    }
+
+    EntityPacketsBuilder withSpawnEntity(int entityId, EntityType type, DecentPosition position) {
+        ClientboundAddEntityPacket packet = new ClientboundAddEntityPacket(
+                entityId,
+                UUID.randomUUID(),
+                position.getX(),
+                position.getY(),
+                position.getZ(),
+                position.getPitch(),
+                position.getYaw(),
+                EntityTypeRegistry.findEntityTypes(type),
+                type == EntityType.ITEM ? 1 : 0,
+                Vec3.ZERO,
+                position.getYaw()
+        );
+
+        packets.add(packet);
+        return this;
+    }
+
+    EntityPacketsBuilder withEntityMetadata(int entityId, List<SynchedEntityData.DataItem<?>> items) {
+        List<SynchedEntityData.DataValue<?>> cs = new ArrayList<>();
+        for (SynchedEntityData.DataItem<?> item : items) {
+            cs.add(item.value());
+        }
+
+        ClientboundSetEntityDataPacket packet = new ClientboundSetEntityDataPacket(entityId, cs);
+        packets.add(packet);
+        return this;
+    }
+
+    EntityPacketsBuilder withHelmet(int entityId, ItemStack itemStack) {
+        Pair<net.minecraft.world.entity.EquipmentSlot, net.minecraft.world.item.ItemStack> equipmentPair = new Pair<>(
+                CraftEquipmentSlot.getNMS(EquipmentSlot.HEAD),
+                itemStackToNms(itemStack)
+        );
+        ClientboundSetEquipmentPacket packet = new ClientboundSetEquipmentPacket(
+                entityId,
+                Collections.singletonList(equipmentPair)
+        );
+        packets.add(packet);
+        return this;
+    }
+
+    EntityPacketsBuilder withTeleportEntity(int entityId, DecentPosition position) {
+        Vec3 locationVec3 = new Vec3(position.getX(), position.getY(), position.getZ());
+        Vec3 zeroVec3 = new Vec3(0, 0, 0);
+        ClientboundTeleportEntityPacket packet = new ClientboundTeleportEntityPacket(
+                entityId,
+                new PositionMoveRotation(locationVec3, zeroVec3, position.getYaw(), position.getPitch()),
+                Set.of(),
+                false
+        );
+        packets.add(packet);
+        return this;
+    }
+
+    EntityPacketsBuilder withPassenger(int entityId, int passenger) {
+        return updatePassenger(entityId, passenger);
+    }
+
+    EntityPacketsBuilder withRemovePassenger(int entityId) {
+        return updatePassenger(entityId, -1);
+    }
+
+    private EntityPacketsBuilder updatePassenger(int entityId, int... passengers) {
+        FriendlyByteBufWrapper serializer = FriendlyByteBufWrapper.getInstance();
+        serializer.writeVarInt(entityId);
+        serializer.writeIntArray(passengers);
+
+        ClientboundSetPassengersPacket packet = ClientboundSetPassengersPacket.STREAM_CODEC.decode(serializer.getSerializer());
+        packets.add(packet);
+        return this;
+    }
+
+    EntityPacketsBuilder withRemoveEntity(int entityId) {
+        ClientboundRemoveEntitiesPacket packet = new ClientboundRemoveEntitiesPacket(entityId);
+        packets.add(packet);
+        return this;
+    }
+
+    private void sendPacket(Player player, Packet<?> packet) {
+        ((CraftPlayer) player).getHandle().connection.send(packet);
+    }
+
+    private net.minecraft.world.item.ItemStack itemStackToNms(ItemStack itemStack) {
+        return CraftItemStack.asNMSCopy(itemStack);
+    }
+
+    static EntityPacketsBuilder create() {
+        return new EntityPacketsBuilder();
+    }
+
+}

--- a/nms/nms-paper_v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/paper_v1_21_R6/EntityTypeRegistry.java
+++ b/nms/nms-paper_v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/paper_v1_21_R6/EntityTypeRegistry.java
@@ -1,0 +1,38 @@
+package eu.decentsoftware.holograms.nms.paper_v1_21_R6;
+
+import eu.decentsoftware.holograms.nms.api.DecentHologramsNmsException;
+import org.bukkit.NamespacedKey;
+import net.minecraft.world.entity.EntityType;
+
+import java.util.Optional;
+
+final class EntityTypeRegistry {
+
+    private EntityTypeRegistry() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    static double getEntityTypeHeight(org.bukkit.entity.EntityType entityType) {
+        return findEntityTypes(entityType).getDimensions().height();
+    }
+
+    static EntityType<?> findEntityTypes(org.bukkit.entity.EntityType entityType) {
+        NamespacedKey namespacedKey = getNamespacedKey(entityType);
+        String key = namespacedKey.getKey();
+        Optional<EntityType<?>> entityTypes = EntityType.byString(key);
+        if (entityTypes.isPresent()) {
+            return entityTypes.get();
+        }
+        throw new DecentHologramsNmsException("Invalid entity type: " + entityType);
+    }
+
+    private static NamespacedKey getNamespacedKey(org.bukkit.entity.EntityType entityType) {
+        try {
+            // Using the deprecated #getKey method because #getKeyOrThrow and #getKeyOrNull don't exist on Paper.
+            return entityType.getKey();
+        } catch (IllegalStateException e) {
+            throw new DecentHologramsNmsException("Couldn't get key for entity type: " + entityType);
+        }
+    }
+
+}

--- a/nms/nms-paper_v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/paper_v1_21_R6/HeadHologramRenderer.java
+++ b/nms/nms-paper_v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/paper_v1_21_R6/HeadHologramRenderer.java
@@ -1,0 +1,75 @@
+package eu.decentsoftware.holograms.nms.paper_v1_21_R6;
+
+import eu.decentsoftware.holograms.nms.api.NmsHologramPartData;
+import eu.decentsoftware.holograms.nms.api.renderer.NmsHeadHologramRenderer;
+import eu.decentsoftware.holograms.shared.DecentPosition;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+class HeadHologramRenderer implements NmsHeadHologramRenderer {
+
+    private final int entityId;
+    private final boolean small;
+
+    HeadHologramRenderer(EntityIdGenerator entityIdGenerator) {
+        this(entityIdGenerator, false);
+    }
+
+    protected HeadHologramRenderer(EntityIdGenerator entityIdGenerator, boolean small) {
+        this.entityId = entityIdGenerator.getFreeEntityId();
+        this.small = small;
+    }
+
+    @Override
+    public void display(Player player, NmsHologramPartData<ItemStack> data) {
+        DecentPosition position = data.getPosition();
+        ItemStack content = data.getContent();
+        DecentPosition offsetPosition = offsetPosition(position);
+        EntityPacketsBuilder.create()
+                .withSpawnEntity(entityId, EntityType.ARMOR_STAND, offsetPosition)
+                .withEntityMetadata(entityId, EntityMetadataBuilder.create()
+                        .withInvisible()
+                        .withNoGravity()
+                        .withArmorStandProperties(small, true)
+                        .toWatchableObjects())
+                .withHelmet(entityId, content)
+                .sendTo(player);
+    }
+
+    @Override
+    public void updateContent(Player player, NmsHologramPartData<ItemStack> data) {
+        EntityPacketsBuilder.create()
+                .withHelmet(entityId, data.getContent())
+                .sendTo(player);
+    }
+
+    @Override
+    public void move(Player player, NmsHologramPartData<ItemStack> data) {
+        EntityPacketsBuilder.create()
+                .withTeleportEntity(entityId, offsetPosition(data.getPosition()))
+                .sendTo(player);
+    }
+
+    @Override
+    public void hide(Player player) {
+        EntityPacketsBuilder.create()
+                .withRemoveEntity(entityId)
+                .sendTo(player);
+    }
+
+    @Override
+    public double getHeight(NmsHologramPartData<ItemStack> data) {
+        return small ? 0.5d : 0.7d;
+    }
+
+    @Override
+    public int[] getEntityIds() {
+        return new int[]{entityId};
+    }
+
+    private DecentPosition offsetPosition(DecentPosition position) {
+        double offsetY = small ? 1.1875d : 2.0d;
+        return position.subtractY(offsetY);
+    }
+}

--- a/nms/nms-paper_v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/paper_v1_21_R6/HologramRendererFactory.java
+++ b/nms/nms-paper_v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/paper_v1_21_R6/HologramRendererFactory.java
@@ -1,0 +1,49 @@
+package eu.decentsoftware.holograms.nms.paper_v1_21_R6;
+
+import eu.decentsoftware.holograms.nms.api.renderer.NmsClickableHologramRenderer;
+import eu.decentsoftware.holograms.nms.api.renderer.NmsEntityHologramRenderer;
+import eu.decentsoftware.holograms.nms.api.renderer.NmsHeadHologramRenderer;
+import eu.decentsoftware.holograms.nms.api.renderer.NmsHologramRendererFactory;
+import eu.decentsoftware.holograms.nms.api.renderer.NmsIconHologramRenderer;
+import eu.decentsoftware.holograms.nms.api.renderer.NmsSmallHeadHologramRenderer;
+import eu.decentsoftware.holograms.nms.api.renderer.NmsTextHologramRenderer;
+
+class HologramRendererFactory implements NmsHologramRendererFactory {
+
+    private final EntityIdGenerator entityIdGenerator;
+
+    HologramRendererFactory(EntityIdGenerator entityIdGenerator) {
+        this.entityIdGenerator = entityIdGenerator;
+    }
+
+    @Override
+    public NmsTextHologramRenderer createTextRenderer() {
+        return new TextHologramRenderer(entityIdGenerator);
+    }
+
+    @Override
+    public NmsIconHologramRenderer createIconRenderer() {
+        return new IconHologramRenderer(entityIdGenerator);
+    }
+
+    @Override
+    public NmsHeadHologramRenderer createHeadRenderer() {
+        return new HeadHologramRenderer(entityIdGenerator);
+    }
+
+    @Override
+    public NmsSmallHeadHologramRenderer createSmallHeadRenderer() {
+        return new SmallHeadHologramRenderer(entityIdGenerator);
+    }
+
+    @Override
+    public NmsEntityHologramRenderer createEntityRenderer() {
+        return new EntityHologramRenderer(entityIdGenerator);
+    }
+
+    @Override
+    public NmsClickableHologramRenderer createClickableRenderer() {
+        return new ClickableHologramRenderer(entityIdGenerator);
+    }
+
+}

--- a/nms/nms-paper_v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/paper_v1_21_R6/IconHologramRenderer.java
+++ b/nms/nms-paper_v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/paper_v1_21_R6/IconHologramRenderer.java
@@ -1,0 +1,77 @@
+package eu.decentsoftware.holograms.nms.paper_v1_21_R6;
+
+import eu.decentsoftware.holograms.nms.api.NmsHologramPartData;
+import eu.decentsoftware.holograms.nms.api.renderer.NmsIconHologramRenderer;
+import eu.decentsoftware.holograms.shared.DecentPosition;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+class IconHologramRenderer implements NmsIconHologramRenderer {
+
+    private final int itemEntityId;
+    private final int armorStandEntityId;
+
+    IconHologramRenderer(EntityIdGenerator entityIdGenerator) {
+        this.itemEntityId = entityIdGenerator.getFreeEntityId();
+        this.armorStandEntityId = entityIdGenerator.getFreeEntityId();
+    }
+
+    @Override
+    public void display(Player player, NmsHologramPartData<ItemStack> data) {
+        DecentPosition position = data.getPosition();
+        ItemStack content = data.getContent();
+        EntityPacketsBuilder.create()
+                .withSpawnEntity(armorStandEntityId, EntityType.ARMOR_STAND, offsetPosition(position))
+                .withEntityMetadata(armorStandEntityId, EntityMetadataBuilder.create()
+                        .withInvisible()
+                        .withArmorStandProperties(true, true)
+                        .toWatchableObjects())
+                .withSpawnEntity(itemEntityId, EntityType.ITEM, position)
+                .withEntityMetadata(itemEntityId, EntityMetadataBuilder.create()
+                        .withItemStack(content)
+                        .toWatchableObjects())
+                .withTeleportEntity(itemEntityId, position)
+                .withPassenger(armorStandEntityId, itemEntityId)
+                .sendTo(player);
+    }
+
+    @Override
+    public void updateContent(Player player, NmsHologramPartData<ItemStack> data) {
+        EntityPacketsBuilder.create()
+                .withEntityMetadata(itemEntityId, EntityMetadataBuilder.create()
+                        .withItemStack(data.getContent())
+                        .toWatchableObjects())
+                .sendTo(player);
+    }
+
+    @Override
+    public void move(Player player, NmsHologramPartData<ItemStack> data) {
+        EntityPacketsBuilder.create()
+                .withTeleportEntity(armorStandEntityId, offsetPosition(data.getPosition()))
+                .sendTo(player);
+    }
+
+    @Override
+    public void hide(Player player) {
+        EntityPacketsBuilder.create()
+                .withRemovePassenger(armorStandEntityId)
+                .withRemoveEntity(itemEntityId)
+                .withRemoveEntity(armorStandEntityId)
+                .sendTo(player);
+    }
+
+    @Override
+    public double getHeight(NmsHologramPartData<ItemStack> data) {
+        return 0.5d;
+    }
+
+    @Override
+    public int[] getEntityIds() {
+        return new int[]{armorStandEntityId, itemEntityId};
+    }
+
+    private DecentPosition offsetPosition(DecentPosition position) {
+        return position.subtractY(0.55);
+    }
+}

--- a/nms/nms-paper_v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/paper_v1_21_R6/InboundPacketHandler.java
+++ b/nms/nms-paper_v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/paper_v1_21_R6/InboundPacketHandler.java
@@ -1,0 +1,57 @@
+package eu.decentsoftware.holograms.nms.paper_v1_21_R6;
+
+import eu.decentsoftware.holograms.nms.api.DecentHologramsNmsException;
+import eu.decentsoftware.holograms.nms.api.NmsPacketListener;
+import eu.decentsoftware.holograms.nms.api.event.NmsEntityInteractAction;
+import eu.decentsoftware.holograms.nms.api.event.NmsEntityInteractEvent;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import net.minecraft.network.protocol.game.ServerboundInteractPacket;
+import org.bukkit.entity.Player;
+
+class InboundPacketHandler extends ChannelInboundHandlerAdapter {
+
+    private final Player player;
+    private final NmsPacketListener listener;
+
+    InboundPacketHandler(Player player, NmsPacketListener listener) {
+        this.player = player;
+        this.listener = listener;
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object packet) throws Exception {
+        if (packet instanceof ServerboundInteractPacket serverboundInteractPacket) {
+            FriendlyByteBufWrapper serializer = FriendlyByteBufWrapper.getInstance();
+            ServerboundInteractPacket.STREAM_CODEC.encode(serializer.getSerializer(), serverboundInteractPacket);
+
+            int entityId = serializer.readVarInt();
+            int actionEnumValueOrdinal = serializer.readVarInt();
+
+            NmsEntityInteractAction action = mapActionEnumValueOrdinalToNmsEntityInteractionAction(actionEnumValueOrdinal);
+            NmsEntityInteractEvent event = new NmsEntityInteractEvent(player, entityId, action);
+            listener.onEntityInteract(event);
+            if (event.isHandled()) {
+                return;
+            }
+        }
+        super.channelRead(ctx, packet);
+    }
+
+    private NmsEntityInteractAction mapActionEnumValueOrdinalToNmsEntityInteractionAction(int ordinal) {
+        // 0 = INTERACT
+        // 1 = ATTACK
+        // 2 = INTERACT_AT
+        //
+        // https://minecraft.wiki/w/Java_Edition_protocol#Interact
+        return switch (ordinal) {
+            case 1:
+                yield player.isSneaking() ? NmsEntityInteractAction.SHIFT_LEFT_CLICK : NmsEntityInteractAction.LEFT_CLICK;
+            case 0, 2:
+                yield player.isSneaking() ? NmsEntityInteractAction.SHIFT_RIGHT_CLICK : NmsEntityInteractAction.RIGHT_CLICK;
+            default:
+                throw new DecentHologramsNmsException("Unknown entity use action: " + ordinal);
+        };
+    }
+
+}

--- a/nms/nms-paper_v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/paper_v1_21_R6/NmsAdapterImpl.java
+++ b/nms/nms-paper_v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/paper_v1_21_R6/NmsAdapterImpl.java
@@ -1,0 +1,103 @@
+package eu.decentsoftware.holograms.nms.paper_v1_21_R6;
+
+import eu.decentsoftware.holograms.nms.api.DecentHologramsNmsException;
+import eu.decentsoftware.holograms.nms.api.NmsAdapter;
+import eu.decentsoftware.holograms.nms.api.NmsPacketListener;
+import eu.decentsoftware.holograms.nms.api.renderer.NmsHologramRendererFactory;
+import eu.decentsoftware.holograms.shared.reflect.ReflectField;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoop;
+import net.minecraft.network.Connection;
+import net.minecraft.server.network.ServerCommonPacketListenerImpl;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import org.bukkit.craftbukkit.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+@SuppressWarnings("unused") // Instantiated via reflection
+public class NmsAdapterImpl implements NmsAdapter {
+
+    private static final String PACKET_HANDLER_NAME = "decent_holograms_packet_handler";
+    private static final String DEFAULT_PIPELINE_TAIL = "DefaultChannelPipeline$TailContext#0";
+    private static final ReflectField<Connection> NETWORK_MANAGER_FIELD = new ReflectField<>(
+            ServerCommonPacketListenerImpl.class, "connection");
+    private final HologramRendererFactory hologramComponentFactory;
+
+    public NmsAdapterImpl() {
+        this.hologramComponentFactory = new HologramRendererFactory(new EntityIdGenerator());
+    }
+
+    @Override
+    public NmsHologramRendererFactory getHologramComponentFactory() {
+        return hologramComponentFactory;
+    }
+
+    @Override
+    public void registerPacketListener(Player player, NmsPacketListener listener) {
+        Objects.requireNonNull(player, "player cannot be null");
+        Objects.requireNonNull(listener, "listener cannot be null");
+
+        executeOnPipelineInEventLoop(player, pipeline -> {
+            if (pipeline.get(PACKET_HANDLER_NAME) != null) {
+                pipeline.remove(PACKET_HANDLER_NAME);
+            }
+            pipeline.addBefore("packet_handler", PACKET_HANDLER_NAME, new InboundPacketHandler(player, listener));
+        });
+    }
+
+    @Override
+    public void unregisterPacketListener(Player player) {
+        Objects.requireNonNull(player, "player cannot be null");
+
+        executeOnPipelineInEventLoop(player, pipeline -> {
+            if (pipeline.get(PACKET_HANDLER_NAME) != null) {
+                pipeline.remove(PACKET_HANDLER_NAME);
+            }
+        });
+    }
+
+    private void executeOnPipelineInEventLoop(Player player, Consumer<ChannelPipeline> task) {
+        ChannelPipeline pipeline = getPipeline(player);
+        EventLoop eventLoop = pipeline.channel().eventLoop();
+
+        if (eventLoop.inEventLoop()) {
+            executeOnPipeline(player, task, pipeline);
+        } else {
+            eventLoop.execute(() -> executeOnPipeline(player, task, pipeline));
+        }
+    }
+
+    private ChannelPipeline getPipeline(Player player) {
+        ServerGamePacketListenerImpl playerConnection = ((CraftPlayer) player).getHandle().connection;
+        Connection networkManager = NETWORK_MANAGER_FIELD.get(playerConnection);
+        return networkManager.channel.pipeline();
+    }
+
+    private void executeOnPipeline(Player player, Consumer<ChannelPipeline> task, ChannelPipeline pipeline) {
+        if (!player.isOnline()) {
+            return;
+        }
+
+        try {
+            task.accept(pipeline);
+        } catch (NoSuchElementException e) {
+            List<String> handlers = pipeline.names();
+            if (handlers.size() == 1 && handlers.getFirst().equals(DEFAULT_PIPELINE_TAIL)) {
+                // player disconnected immediately after joining
+                return;
+            }
+            throwFailedToModifyPipelineException(player, e);
+        } catch (Exception e) {
+            throwFailedToModifyPipelineException(player, e);
+        }
+    }
+
+    private void throwFailedToModifyPipelineException(Player player, Exception e) {
+        throw new DecentHologramsNmsException("Failed to modify player's pipeline. player: " + player.getName(), e);
+    }
+
+}

--- a/nms/nms-paper_v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/paper_v1_21_R6/PacketDataSerializerWrapper.java
+++ b/nms/nms-paper_v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/paper_v1_21_R6/PacketDataSerializerWrapper.java
@@ -1,0 +1,42 @@
+package eu.decentsoftware.holograms.nms.paper_v1_21_R6;
+
+import io.netty.buffer.Unpooled;
+import net.minecraft.network.FriendlyByteBuf;
+
+class FriendlyByteBufWrapper {
+
+    private static final ThreadLocal<FriendlyByteBufWrapper> LOCAL_INSTANCE = ThreadLocal.withInitial(
+            FriendlyByteBufWrapper::new);
+    private final FriendlyByteBuf serializer;
+
+    private FriendlyByteBufWrapper() {
+        this.serializer = new FriendlyByteBuf(Unpooled.buffer());
+    }
+
+    FriendlyByteBuf getSerializer() {
+        return serializer;
+    }
+
+    void clear() {
+        serializer.clear();
+    }
+
+    void writeIntArray(int[] array) {
+        serializer.writeVarIntArray(array);
+    }
+
+    void writeVarInt(int value) {
+        serializer.writeVarInt(value);
+    }
+
+    int readVarInt() {
+        return serializer.readVarInt();
+    }
+
+    static FriendlyByteBufWrapper getInstance() {
+        FriendlyByteBufWrapper instance = LOCAL_INSTANCE.get();
+        instance.clear();
+        return instance;
+    }
+
+}

--- a/nms/nms-paper_v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/paper_v1_21_R6/SmallHeadHologramRenderer.java
+++ b/nms/nms-paper_v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/paper_v1_21_R6/SmallHeadHologramRenderer.java
@@ -1,0 +1,11 @@
+package eu.decentsoftware.holograms.nms.paper_v1_21_R6;
+
+import eu.decentsoftware.holograms.nms.api.renderer.NmsSmallHeadHologramRenderer;
+
+class SmallHeadHologramRenderer extends HeadHologramRenderer implements NmsSmallHeadHologramRenderer {
+
+    SmallHeadHologramRenderer(EntityIdGenerator entityIdGenerator) {
+        super(entityIdGenerator, true);
+    }
+
+}

--- a/nms/nms-paper_v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/paper_v1_21_R6/TextHologramRenderer.java
+++ b/nms/nms-paper_v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/paper_v1_21_R6/TextHologramRenderer.java
@@ -1,0 +1,68 @@
+package eu.decentsoftware.holograms.nms.paper_v1_21_R6;
+
+import eu.decentsoftware.holograms.nms.api.NmsHologramPartData;
+import eu.decentsoftware.holograms.nms.api.renderer.NmsTextHologramRenderer;
+import eu.decentsoftware.holograms.shared.DecentPosition;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+
+class TextHologramRenderer implements NmsTextHologramRenderer {
+
+    private final int armorStandEntityId;
+
+    TextHologramRenderer(EntityIdGenerator entityIdGenerator) {
+        this.armorStandEntityId = entityIdGenerator.getFreeEntityId();
+    }
+
+    @Override
+    public void display(Player player, NmsHologramPartData<String> data) {
+        String content = data.getContent();
+        DecentPosition position = data.getPosition();
+        EntityPacketsBuilder.create()
+                .withSpawnEntity(armorStandEntityId, EntityType.ARMOR_STAND, offsetPosition(position))
+                .withEntityMetadata(armorStandEntityId, EntityMetadataBuilder.create()
+                        .withInvisible()
+                        .withNoGravity()
+                        .withArmorStandProperties(true, true)
+                        .withCustomName(content)
+                        .toWatchableObjects())
+                .sendTo(player);
+    }
+
+    @Override
+    public void updateContent(Player player, NmsHologramPartData<String> data) {
+        EntityPacketsBuilder.create()
+                .withEntityMetadata(armorStandEntityId, EntityMetadataBuilder.create()
+                        .withCustomName(data.getContent())
+                        .toWatchableObjects())
+                .sendTo(player);
+    }
+
+    @Override
+    public void move(Player player, NmsHologramPartData<String> data) {
+        EntityPacketsBuilder.create()
+                .withTeleportEntity(armorStandEntityId, offsetPosition(data.getPosition()))
+                .sendTo(player);
+    }
+
+    @Override
+    public void hide(Player player) {
+        EntityPacketsBuilder.create()
+                .withRemoveEntity(armorStandEntityId)
+                .sendTo(player);
+    }
+
+    @Override
+    public double getHeight(NmsHologramPartData<String> data) {
+        return 0.25d;
+    }
+
+    @Override
+    public int[] getEntityIds() {
+        return new int[]{armorStandEntityId};
+    }
+
+    private DecentPosition offsetPosition(DecentPosition position) {
+        return position.subtractY(0.5);
+    }
+}

--- a/nms/nms-v1_21_R6/build.gradle
+++ b/nms/nms-v1_21_R6/build.gradle
@@ -1,0 +1,18 @@
+repositories {
+    maven { url = "https://libraries.minecraft.net/" }
+}
+
+dependencies {
+    compileOnly "org.spigotmc:spigot:1.21.9-R0.1-SNAPSHOT"
+}
+
+compileJava {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}

--- a/nms/nms-v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/v1_21_R6/ClickableHologramRenderer.java
+++ b/nms/nms-v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/v1_21_R6/ClickableHologramRenderer.java
@@ -1,0 +1,46 @@
+package eu.decentsoftware.holograms.nms.v1_21_R6;
+
+import eu.decentsoftware.holograms.nms.api.renderer.NmsClickableHologramRenderer;
+import eu.decentsoftware.holograms.shared.DecentPosition;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+
+class ClickableHologramRenderer implements NmsClickableHologramRenderer {
+
+    private final int entityId;
+
+    ClickableHologramRenderer(EntityIdGenerator entityIdGenerator) {
+        this.entityId = entityIdGenerator.getFreeEntityId();
+    }
+
+    @Override
+    public void display(Player player, DecentPosition position) {
+        EntityPacketsBuilder.create()
+                .withSpawnEntity(entityId, EntityType.ARMOR_STAND, position)
+                .withEntityMetadata(entityId, EntityMetadataBuilder.create()
+                        .withInvisible()
+                        .withNoGravity()
+                        .withArmorStandProperties(false, false)
+                        .toWatchableObjects())
+                .sendTo(player);
+    }
+
+    @Override
+    public void move(Player player, DecentPosition position) {
+        EntityPacketsBuilder.create()
+                .withTeleportEntity(entityId, position)
+                .sendTo(player);
+    }
+
+    @Override
+    public void hide(Player player) {
+        EntityPacketsBuilder.create()
+                .withRemoveEntity(entityId)
+                .sendTo(player);
+    }
+
+    @Override
+    public int getEntityId() {
+        return entityId;
+    }
+}

--- a/nms/nms-v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/v1_21_R6/EntityHologramRenderer.java
+++ b/nms/nms-v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/v1_21_R6/EntityHologramRenderer.java
@@ -1,0 +1,63 @@
+package eu.decentsoftware.holograms.nms.v1_21_R6;
+
+import eu.decentsoftware.holograms.nms.api.NmsHologramPartData;
+import eu.decentsoftware.holograms.nms.api.renderer.NmsEntityHologramRenderer;
+import eu.decentsoftware.holograms.shared.DecentPosition;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+
+class EntityHologramRenderer implements NmsEntityHologramRenderer {
+
+    private final int entityId;
+
+    EntityHologramRenderer(EntityIdGenerator entityIdGenerator) {
+        this.entityId = entityIdGenerator.getFreeEntityId();
+    }
+
+    @Override
+    public void display(Player player, NmsHologramPartData<EntityType> data) {
+        DecentPosition position = data.getPosition();
+        EntityType content = data.getContent();
+        DecentPosition offsetPosition = offsetPosition(position);
+        EntityPacketsBuilder.create()
+                .withSpawnEntity(entityId, content, offsetPosition)
+                .withEntityMetadata(entityId, EntityMetadataBuilder.create()
+                        .withSilent()
+                        .withNoGravity()
+                        .toWatchableObjects())
+                .sendTo(player);
+    }
+
+    @Override
+    public void updateContent(Player player, NmsHologramPartData<EntityType> data) {
+        hide(player);
+        display(player, data);
+    }
+
+    @Override
+    public void move(Player player, NmsHologramPartData<EntityType> data) {
+        hide(player);
+        display(player, data);
+    }
+
+    @Override
+    public void hide(Player player) {
+        EntityPacketsBuilder.create()
+                .withRemoveEntity(entityId)
+                .sendTo(player);
+    }
+
+    @Override
+    public double getHeight(NmsHologramPartData<EntityType> data) {
+        return EntityTypeRegistry.getEntityTypeHeight(data.getContent());
+    }
+
+    @Override
+    public int[] getEntityIds() {
+        return new int[]{entityId};
+    }
+
+    private DecentPosition offsetPosition(DecentPosition position) {
+        return position.subtractY(0.25d);
+    }
+}

--- a/nms/nms-v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/v1_21_R6/EntityIdGenerator.java
+++ b/nms/nms-v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/v1_21_R6/EntityIdGenerator.java
@@ -1,0 +1,26 @@
+package eu.decentsoftware.holograms.nms.v1_21_R6;
+
+import eu.decentsoftware.holograms.nms.api.DecentHologramsNmsException;
+import eu.decentsoftware.holograms.shared.reflect.ReflectField;
+import net.minecraft.world.entity.Entity;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+class EntityIdGenerator {
+
+    private static final ReflectField<AtomicInteger> ENTITY_COUNT_FIELD = new ReflectField<>(Entity.class, "c", "ENTITY_COUNTER");
+
+    int getFreeEntityId() {
+        try {
+            /*
+             * We are getting the new entity ids the same way as the server does. This is to ensure
+             * that the ids are unique and don't conflict with any other entities.
+             */
+            AtomicInteger entityCount = ENTITY_COUNT_FIELD.get(null);
+            return entityCount.incrementAndGet();
+        } catch (Exception e) {
+            throw new DecentHologramsNmsException("Failed to get new entity ID", e);
+        }
+    }
+
+}

--- a/nms/nms-v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/v1_21_R6/EntityMetadataBuilder.java
+++ b/nms/nms-v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/v1_21_R6/EntityMetadataBuilder.java
@@ -1,0 +1,92 @@
+package eu.decentsoftware.holograms.nms.v1_21_R6;
+
+import com.google.common.base.Strings;
+import net.minecraft.network.chat.IChatBaseComponent;
+import net.minecraft.network.syncher.DataWatcher;
+import org.bukkit.craftbukkit.v1_21_R6.inventory.CraftItemStack;
+import org.bukkit.craftbukkit.v1_21_R6.util.CraftChatMessage;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+class EntityMetadataBuilder {
+
+    private final List<DataWatcher.Item<?>> watchableObjects;
+
+    private EntityMetadataBuilder() {
+        this.watchableObjects = new ArrayList<>();
+    }
+
+    List<DataWatcher.Item<?>> toWatchableObjects() {
+        return watchableObjects;
+    }
+
+    EntityMetadataBuilder withInvisible() {
+        /*
+         * Entity Properties:
+         * 0x01 - On Fire
+         * 0x02 - Crouched
+         * 0x08 - Sprinting
+         * 0x10 - Swimming
+         * 0x20 - Invisible
+         * 0x40 - Has glowing effect
+         * 0x80 - If flying with an elytra
+         */
+
+        watchableObjects.add(EntityMetadataType.ENTITY_PROPERTIES.construct((byte) 0x20));
+        return this;
+    }
+
+    EntityMetadataBuilder withArmorStandProperties(boolean small, boolean marker) {
+        /*
+         * Armor Stand Properties:
+         * 0x01 - Small
+         * 0x02 - Unused
+         * 0x04 - Has Arms
+         * 0x08 - Remove Baseplate
+         * 0x10 - Marker (Zero bounding box)
+         */
+
+        byte data = 0x08; // Always Remove Baseplate
+        if (small) {
+            data |= 0x01;
+        }
+        if (marker) {
+            data |= 0x10;
+        }
+
+        watchableObjects.add(EntityMetadataType.ARMOR_STAND_PROPERTIES.construct(data));
+        return this;
+    }
+
+    EntityMetadataBuilder withCustomName(String customName) {
+        IChatBaseComponent iChatBaseComponent = CraftChatMessage.fromStringOrNull(customName);
+        Optional<IChatBaseComponent> optionalIChatBaseComponent = Optional.ofNullable(iChatBaseComponent);
+        watchableObjects.add(EntityMetadataType.ENTITY_CUSTOM_NAME.construct(optionalIChatBaseComponent));
+        boolean visible = !Strings.isNullOrEmpty(customName);
+        watchableObjects.add(EntityMetadataType.ENTITY_CUSTOM_NAME_VISIBLE.construct(visible));
+        return this;
+    }
+
+    EntityMetadataBuilder withItemStack(ItemStack itemStack) {
+        watchableObjects.add(EntityMetadataType.ITEM_STACK.construct(CraftItemStack.asNMSCopy(itemStack)));
+        return this;
+    }
+
+    EntityMetadataBuilder withSilent() {
+        watchableObjects.add(EntityMetadataType.ENTITY_SILENT.construct(true));
+        return this;
+    }
+
+    EntityMetadataBuilder withNoGravity() {
+        watchableObjects.add(EntityMetadataType.ENTITY_HAS_NO_GRAVITY.construct(true));
+        return this;
+    }
+
+    static EntityMetadataBuilder create() {
+        return new EntityMetadataBuilder();
+    }
+
+}

--- a/nms/nms-v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/v1_21_R6/EntityMetadataType.java
+++ b/nms/nms-v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/v1_21_R6/EntityMetadataType.java
@@ -1,0 +1,49 @@
+package eu.decentsoftware.holograms.nms.v1_21_R6;
+
+import eu.decentsoftware.holograms.shared.reflect.ReflectUtil;
+import net.minecraft.network.chat.IChatBaseComponent;
+import net.minecraft.network.syncher.DataWatcher;
+import net.minecraft.network.syncher.DataWatcherObject;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.decoration.EntityArmorStand;
+import net.minecraft.world.entity.item.EntityItem;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.Optional;
+
+class EntityMetadataType<T> {
+
+    private static final DataWatcherObject<Byte> ENTITY_PROPERTIES_OBJECT
+            = ReflectUtil.getFieldValue(Entity.class, "aA", "DATA_SHARED_FLAGS_ID");
+    private static final DataWatcherObject<Optional<IChatBaseComponent>> ENTITY_CUSTOM_NAME_OBJECT
+            = ReflectUtil.getFieldValue(Entity.class, "bm", "DATA_CUSTOM_NAME");
+    private static final DataWatcherObject<Boolean> ENTITY_CUSTOM_NAME_VISIBLE_OBJECT
+            = ReflectUtil.getFieldValue(Entity.class, "bn", "DATA_CUSTOM_NAME_VISIBLE");
+    private static final DataWatcherObject<Boolean> ENTITY_SILENT_OBJECT
+            = ReflectUtil.getFieldValue(Entity.class, "bo", "DATA_SILENT");
+    private static final DataWatcherObject<Boolean> ENTITY_HAS_NO_GRAVITY_OBJECT
+            = ReflectUtil.getFieldValue(Entity.class, "bp", "DATA_NO_GRAVITY");
+    private static final DataWatcherObject<Byte> ARMOR_STAND_PROPERTIES_OBJECT
+            = ReflectUtil.getFieldValue(EntityArmorStand.class, "n", "DATA_CLIENT_FLAGS");
+    private static final DataWatcherObject<ItemStack> ITEM_STACK_OBJECT
+            = ReflectUtil.getFieldValue(EntityItem.class, "c", "DATA_ITEM");
+
+    static final EntityMetadataType<Byte> ENTITY_PROPERTIES = new EntityMetadataType<>(ENTITY_PROPERTIES_OBJECT);
+    static final EntityMetadataType<Optional<IChatBaseComponent>> ENTITY_CUSTOM_NAME = new EntityMetadataType<>(ENTITY_CUSTOM_NAME_OBJECT);
+    static final EntityMetadataType<Boolean> ENTITY_CUSTOM_NAME_VISIBLE = new EntityMetadataType<>(ENTITY_CUSTOM_NAME_VISIBLE_OBJECT);
+    static final EntityMetadataType<Boolean> ENTITY_SILENT = new EntityMetadataType<>(ENTITY_SILENT_OBJECT);
+    static final EntityMetadataType<Boolean> ENTITY_HAS_NO_GRAVITY = new EntityMetadataType<>(ENTITY_HAS_NO_GRAVITY_OBJECT);
+    static final EntityMetadataType<Byte> ARMOR_STAND_PROPERTIES = new EntityMetadataType<>(ARMOR_STAND_PROPERTIES_OBJECT);
+    static final EntityMetadataType<ItemStack> ITEM_STACK = new EntityMetadataType<>(ITEM_STACK_OBJECT);
+
+    private final DataWatcherObject<T> dataWatcherObject;
+
+    private EntityMetadataType(DataWatcherObject<T> dataWatcherObject) {
+        this.dataWatcherObject = dataWatcherObject;
+    }
+
+    DataWatcher.Item<T> construct(T value) {
+        return new DataWatcher.Item<>(dataWatcherObject, value);
+    }
+
+}

--- a/nms/nms-v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/v1_21_R6/EntityPacketsBuilder.java
+++ b/nms/nms-v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/v1_21_R6/EntityPacketsBuilder.java
@@ -1,0 +1,135 @@
+package eu.decentsoftware.holograms.nms.v1_21_R6;
+
+import com.mojang.datafixers.util.Pair;
+import eu.decentsoftware.holograms.shared.DecentPosition;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.PacketPlayOutEntityDestroy;
+import net.minecraft.network.protocol.game.PacketPlayOutEntityEquipment;
+import net.minecraft.network.protocol.game.PacketPlayOutEntityMetadata;
+import net.minecraft.network.protocol.game.PacketPlayOutEntityTeleport;
+import net.minecraft.network.protocol.game.PacketPlayOutMount;
+import net.minecraft.network.protocol.game.PacketPlayOutSpawnEntity;
+import net.minecraft.network.syncher.DataWatcher;
+import net.minecraft.world.entity.EnumItemSlot;
+import net.minecraft.world.entity.PositionMoveRotation;
+import net.minecraft.world.phys.Vec3D;
+import org.bukkit.craftbukkit.v1_21_R6.CraftEquipmentSlot;
+import org.bukkit.craftbukkit.v1_21_R6.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_21_R6.inventory.CraftItemStack;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+class EntityPacketsBuilder {
+
+    private final List<Packet<?>> packets;
+
+    private EntityPacketsBuilder() {
+        this.packets = new ArrayList<>();
+    }
+
+    void sendTo(Player player) {
+        for (Packet<?> packet : packets) {
+            sendPacket(player, packet);
+        }
+    }
+
+    EntityPacketsBuilder withSpawnEntity(int entityId, EntityType type, DecentPosition position) {
+        PacketPlayOutSpawnEntity packet = new PacketPlayOutSpawnEntity(
+                entityId,
+                UUID.randomUUID(),
+                position.getX(),
+                position.getY(),
+                position.getZ(),
+                position.getPitch(),
+                position.getYaw(),
+                EntityTypeRegistry.findEntityTypes(type),
+                type == EntityType.ITEM ? 1 : 0,
+                Vec3D.c,
+                position.getYaw()
+        );
+        packets.add(packet);
+        return this;
+    }
+
+    EntityPacketsBuilder withEntityMetadata(int entityId, List<DataWatcher.Item<?>> items) {
+        List<DataWatcher.c<?>> cs = new ArrayList<>();
+        for (DataWatcher.Item<?> item : items) {
+            cs.add(item.e());
+        }
+
+        PacketPlayOutEntityMetadata packet = new PacketPlayOutEntityMetadata(entityId, cs);
+        packets.add(packet);
+        return this;
+    }
+
+    EntityPacketsBuilder withHelmet(int entityId, ItemStack itemStack) {
+        Pair<EnumItemSlot, net.minecraft.world.item.ItemStack> equipmentPair = new Pair<>(
+                CraftEquipmentSlot.getNMS(EquipmentSlot.HEAD),
+                itemStackToNms(itemStack)
+        );
+        PacketPlayOutEntityEquipment packet = new PacketPlayOutEntityEquipment(
+                entityId,
+                Collections.singletonList(equipmentPair)
+        );
+        packets.add(packet);
+        return this;
+    }
+
+    EntityPacketsBuilder withTeleportEntity(int entityId, DecentPosition position) {
+        Vec3D locationVec3D = new Vec3D(position.getX(), position.getY(), position.getZ());
+        Vec3D zeroVec3D = new Vec3D(0, 0, 0);
+        PacketPlayOutEntityTeleport packet = new PacketPlayOutEntityTeleport(
+                entityId,
+                new PositionMoveRotation(locationVec3D, zeroVec3D, position.getYaw(), position.getPitch()),
+                Set.of(),
+                false
+        );
+        packets.add(packet);
+        return this;
+    }
+
+    EntityPacketsBuilder withPassenger(int entityId, int passenger) {
+        return updatePassenger(entityId, passenger);
+    }
+
+    EntityPacketsBuilder withRemovePassenger(int entityId) {
+        return updatePassenger(entityId, -1);
+    }
+
+    private EntityPacketsBuilder updatePassenger(int entityId, int... passengers) {
+        PacketDataSerializerWrapper serializer = PacketDataSerializerWrapper.getInstance();
+        serializer.writeVarInt(entityId);
+        serializer.writeIntArray(passengers);
+
+        PacketPlayOutMount packet = PacketPlayOutMount.a.decode(serializer.getSerializer());
+        packets.add(packet);
+        return this;
+    }
+
+    EntityPacketsBuilder withRemoveEntity(int entityId) {
+        PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entityId);
+        packets.add(packet);
+        return this;
+    }
+
+    private void sendPacket(Player player, Packet<?> packet) {
+        ((CraftPlayer) player).getHandle().g.b(packet);
+    }
+
+    private net.minecraft.world.item.ItemStack itemStackToNms(ItemStack itemStack) {
+        return CraftItemStack.asNMSCopy(itemStack);
+    }
+
+    static EntityPacketsBuilder create() {
+        return new EntityPacketsBuilder();
+    }
+
+}

--- a/nms/nms-v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/v1_21_R6/EntityTypeRegistry.java
+++ b/nms/nms-v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/v1_21_R6/EntityTypeRegistry.java
@@ -1,0 +1,39 @@
+package eu.decentsoftware.holograms.nms.v1_21_R6;
+
+import eu.decentsoftware.holograms.nms.api.DecentHologramsNmsException;
+import net.minecraft.world.entity.EntityTypes;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.EntityType;
+
+import java.util.Optional;
+
+final class EntityTypeRegistry {
+
+    private EntityTypeRegistry() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    static double getEntityTypeHeight(EntityType entityType) {
+        return findEntityTypes(entityType).n().b();
+    }
+
+    static EntityTypes<?> findEntityTypes(EntityType entityType) {
+        NamespacedKey namespacedKey = getNamespacedKey(entityType);
+        String key = namespacedKey.getKey();
+        Optional<EntityTypes<?>> entityTypes = EntityTypes.a(key);
+        if (entityTypes.isPresent()) {
+            return entityTypes.get();
+        }
+        throw new DecentHologramsNmsException("Invalid entity type: " + entityType);
+    }
+
+    private static NamespacedKey getNamespacedKey(EntityType entityType) {
+        try {
+            // Using the deprecated #getKey method because #getKeyOrThrow and #getKeyOrNull don't exist on Paper.
+            return entityType.getKey();
+        } catch (IllegalStateException e) {
+            throw new DecentHologramsNmsException("Couldn't get key for entity type: " + entityType);
+        }
+    }
+
+}

--- a/nms/nms-v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/v1_21_R6/HeadHologramRenderer.java
+++ b/nms/nms-v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/v1_21_R6/HeadHologramRenderer.java
@@ -1,0 +1,75 @@
+package eu.decentsoftware.holograms.nms.v1_21_R6;
+
+import eu.decentsoftware.holograms.nms.api.NmsHologramPartData;
+import eu.decentsoftware.holograms.nms.api.renderer.NmsHeadHologramRenderer;
+import eu.decentsoftware.holograms.shared.DecentPosition;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+class HeadHologramRenderer implements NmsHeadHologramRenderer {
+
+    private final int entityId;
+    private final boolean small;
+
+    HeadHologramRenderer(EntityIdGenerator entityIdGenerator) {
+        this(entityIdGenerator, false);
+    }
+
+    protected HeadHologramRenderer(EntityIdGenerator entityIdGenerator, boolean small) {
+        this.entityId = entityIdGenerator.getFreeEntityId();
+        this.small = small;
+    }
+
+    @Override
+    public void display(Player player, NmsHologramPartData<ItemStack> data) {
+        DecentPosition position = data.getPosition();
+        ItemStack content = data.getContent();
+        DecentPosition offsetPosition = offsetPosition(position);
+        EntityPacketsBuilder.create()
+                .withSpawnEntity(entityId, EntityType.ARMOR_STAND, offsetPosition)
+                .withEntityMetadata(entityId, EntityMetadataBuilder.create()
+                        .withInvisible()
+                        .withNoGravity()
+                        .withArmorStandProperties(small, true)
+                        .toWatchableObjects())
+                .withHelmet(entityId, content)
+                .sendTo(player);
+    }
+
+    @Override
+    public void updateContent(Player player, NmsHologramPartData<ItemStack> data) {
+        EntityPacketsBuilder.create()
+                .withHelmet(entityId, data.getContent())
+                .sendTo(player);
+    }
+
+    @Override
+    public void move(Player player, NmsHologramPartData<ItemStack> data) {
+        EntityPacketsBuilder.create()
+                .withTeleportEntity(entityId, offsetPosition(data.getPosition()))
+                .sendTo(player);
+    }
+
+    @Override
+    public void hide(Player player) {
+        EntityPacketsBuilder.create()
+                .withRemoveEntity(entityId)
+                .sendTo(player);
+    }
+
+    @Override
+    public double getHeight(NmsHologramPartData<ItemStack> data) {
+        return small ? 0.5d : 0.7d;
+    }
+
+    @Override
+    public int[] getEntityIds() {
+        return new int[]{entityId};
+    }
+
+    private DecentPosition offsetPosition(DecentPosition position) {
+        double offsetY = small ? 1.1875d : 2.0d;
+        return position.subtractY(offsetY);
+    }
+}

--- a/nms/nms-v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/v1_21_R6/HologramRendererFactory.java
+++ b/nms/nms-v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/v1_21_R6/HologramRendererFactory.java
@@ -1,0 +1,49 @@
+package eu.decentsoftware.holograms.nms.v1_21_R6;
+
+import eu.decentsoftware.holograms.nms.api.renderer.NmsClickableHologramRenderer;
+import eu.decentsoftware.holograms.nms.api.renderer.NmsEntityHologramRenderer;
+import eu.decentsoftware.holograms.nms.api.renderer.NmsHeadHologramRenderer;
+import eu.decentsoftware.holograms.nms.api.renderer.NmsHologramRendererFactory;
+import eu.decentsoftware.holograms.nms.api.renderer.NmsIconHologramRenderer;
+import eu.decentsoftware.holograms.nms.api.renderer.NmsSmallHeadHologramRenderer;
+import eu.decentsoftware.holograms.nms.api.renderer.NmsTextHologramRenderer;
+
+class HologramRendererFactory implements NmsHologramRendererFactory {
+
+    private final EntityIdGenerator entityIdGenerator;
+
+    HologramRendererFactory(EntityIdGenerator entityIdGenerator) {
+        this.entityIdGenerator = entityIdGenerator;
+    }
+
+    @Override
+    public NmsTextHologramRenderer createTextRenderer() {
+        return new TextHologramRenderer(entityIdGenerator);
+    }
+
+    @Override
+    public NmsIconHologramRenderer createIconRenderer() {
+        return new IconHologramRenderer(entityIdGenerator);
+    }
+
+    @Override
+    public NmsHeadHologramRenderer createHeadRenderer() {
+        return new HeadHologramRenderer(entityIdGenerator);
+    }
+
+    @Override
+    public NmsSmallHeadHologramRenderer createSmallHeadRenderer() {
+        return new SmallHeadHologramRenderer(entityIdGenerator);
+    }
+
+    @Override
+    public NmsEntityHologramRenderer createEntityRenderer() {
+        return new EntityHologramRenderer(entityIdGenerator);
+    }
+
+    @Override
+    public NmsClickableHologramRenderer createClickableRenderer() {
+        return new ClickableHologramRenderer(entityIdGenerator);
+    }
+
+}

--- a/nms/nms-v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/v1_21_R6/IconHologramRenderer.java
+++ b/nms/nms-v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/v1_21_R6/IconHologramRenderer.java
@@ -1,0 +1,77 @@
+package eu.decentsoftware.holograms.nms.v1_21_R6;
+
+import eu.decentsoftware.holograms.nms.api.NmsHologramPartData;
+import eu.decentsoftware.holograms.nms.api.renderer.NmsIconHologramRenderer;
+import eu.decentsoftware.holograms.shared.DecentPosition;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+class IconHologramRenderer implements NmsIconHologramRenderer {
+
+    private final int itemEntityId;
+    private final int armorStandEntityId;
+
+    IconHologramRenderer(EntityIdGenerator entityIdGenerator) {
+        this.itemEntityId = entityIdGenerator.getFreeEntityId();
+        this.armorStandEntityId = entityIdGenerator.getFreeEntityId();
+    }
+
+    @Override
+    public void display(Player player, NmsHologramPartData<ItemStack> data) {
+        DecentPosition position = data.getPosition();
+        ItemStack content = data.getContent();
+        EntityPacketsBuilder.create()
+                .withSpawnEntity(armorStandEntityId, EntityType.ARMOR_STAND, offsetPosition(position))
+                .withEntityMetadata(armorStandEntityId, EntityMetadataBuilder.create()
+                        .withInvisible()
+                        .withArmorStandProperties(true, true)
+                        .toWatchableObjects())
+                .withSpawnEntity(itemEntityId, EntityType.ITEM, position)
+                .withEntityMetadata(itemEntityId, EntityMetadataBuilder.create()
+                        .withItemStack(content)
+                        .toWatchableObjects())
+                .withTeleportEntity(itemEntityId, position)
+                .withPassenger(armorStandEntityId, itemEntityId)
+                .sendTo(player);
+    }
+
+    @Override
+    public void updateContent(Player player, NmsHologramPartData<ItemStack> data) {
+        EntityPacketsBuilder.create()
+                .withEntityMetadata(itemEntityId, EntityMetadataBuilder.create()
+                        .withItemStack(data.getContent())
+                        .toWatchableObjects())
+                .sendTo(player);
+    }
+
+    @Override
+    public void move(Player player, NmsHologramPartData<ItemStack> data) {
+        EntityPacketsBuilder.create()
+                .withTeleportEntity(armorStandEntityId, offsetPosition(data.getPosition()))
+                .sendTo(player);
+    }
+
+    @Override
+    public void hide(Player player) {
+        EntityPacketsBuilder.create()
+                .withRemovePassenger(armorStandEntityId)
+                .withRemoveEntity(itemEntityId)
+                .withRemoveEntity(armorStandEntityId)
+                .sendTo(player);
+    }
+
+    @Override
+    public double getHeight(NmsHologramPartData<ItemStack> data) {
+        return 0.5d;
+    }
+
+    @Override
+    public int[] getEntityIds() {
+        return new int[]{armorStandEntityId, itemEntityId};
+    }
+
+    private DecentPosition offsetPosition(DecentPosition position) {
+        return position.subtractY(0.55);
+    }
+}

--- a/nms/nms-v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/v1_21_R6/InboundPacketHandler.java
+++ b/nms/nms-v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/v1_21_R6/InboundPacketHandler.java
@@ -1,0 +1,57 @@
+package eu.decentsoftware.holograms.nms.v1_21_R6;
+
+import eu.decentsoftware.holograms.nms.api.DecentHologramsNmsException;
+import eu.decentsoftware.holograms.nms.api.NmsPacketListener;
+import eu.decentsoftware.holograms.nms.api.event.NmsEntityInteractAction;
+import eu.decentsoftware.holograms.nms.api.event.NmsEntityInteractEvent;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import net.minecraft.network.protocol.game.PacketPlayInUseEntity;
+import org.bukkit.entity.Player;
+
+class InboundPacketHandler extends ChannelInboundHandlerAdapter {
+
+    private final Player player;
+    private final NmsPacketListener listener;
+
+    InboundPacketHandler(Player player, NmsPacketListener listener) {
+        this.player = player;
+        this.listener = listener;
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object packet) throws Exception {
+        if (packet instanceof PacketPlayInUseEntity packetPlayInUseEntity) {
+            PacketDataSerializerWrapper serializer = PacketDataSerializerWrapper.getInstance();
+            PacketPlayInUseEntity.a.encode(serializer.getSerializer(), packetPlayInUseEntity);
+
+            int entityId = serializer.readVarInt();
+            int actionEnumValueOrdinal = serializer.readVarInt();
+
+            NmsEntityInteractAction action = mapActionEnumValueOrdinalToNmsEntityInteractionAction(actionEnumValueOrdinal);
+            NmsEntityInteractEvent event = new NmsEntityInteractEvent(player, entityId, action);
+            listener.onEntityInteract(event);
+            if (event.isHandled()) {
+                return;
+            }
+        }
+        super.channelRead(ctx, packet);
+    }
+
+    private NmsEntityInteractAction mapActionEnumValueOrdinalToNmsEntityInteractionAction(int ordinal) {
+        // 0 = INTERACT
+        // 1 = ATTACK
+        // 2 = INTERACT_AT
+        //
+        // https://minecraft.wiki/w/Java_Edition_protocol#Interact
+        return switch (ordinal) {
+            case 1:
+                yield player.isSneaking() ? NmsEntityInteractAction.SHIFT_LEFT_CLICK : NmsEntityInteractAction.LEFT_CLICK;
+            case 0, 2:
+                yield player.isSneaking() ? NmsEntityInteractAction.SHIFT_RIGHT_CLICK : NmsEntityInteractAction.RIGHT_CLICK;
+            default:
+                throw new DecentHologramsNmsException("Unknown entity use action: " + ordinal);
+        };
+    }
+
+}

--- a/nms/nms-v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/v1_21_R6/NmsAdapterImpl.java
+++ b/nms/nms-v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/v1_21_R6/NmsAdapterImpl.java
@@ -1,0 +1,103 @@
+package eu.decentsoftware.holograms.nms.v1_21_R6;
+
+import eu.decentsoftware.holograms.nms.api.DecentHologramsNmsException;
+import eu.decentsoftware.holograms.nms.api.NmsAdapter;
+import eu.decentsoftware.holograms.nms.api.NmsPacketListener;
+import eu.decentsoftware.holograms.nms.api.renderer.NmsHologramRendererFactory;
+import eu.decentsoftware.holograms.shared.reflect.ReflectField;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoop;
+import net.minecraft.network.NetworkManager;
+import net.minecraft.server.network.PlayerConnection;
+import net.minecraft.server.network.ServerCommonPacketListenerImpl;
+import org.bukkit.craftbukkit.v1_21_R6.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+@SuppressWarnings("unused") // Instantiated via reflection
+public class NmsAdapterImpl implements NmsAdapter {
+
+    private static final String PACKET_HANDLER_NAME = "decent_holograms_packet_handler";
+    private static final String DEFAULT_PIPELINE_TAIL = "DefaultChannelPipeline$TailContext#0";
+    private static final ReflectField<NetworkManager> NETWORK_MANAGER_FIELD = new ReflectField<>(
+            ServerCommonPacketListenerImpl.class, "e", "connection");
+    private final HologramRendererFactory hologramComponentFactory;
+
+    public NmsAdapterImpl() {
+        this.hologramComponentFactory = new HologramRendererFactory(new EntityIdGenerator());
+    }
+
+    @Override
+    public NmsHologramRendererFactory getHologramComponentFactory() {
+        return hologramComponentFactory;
+    }
+
+    @Override
+    public void registerPacketListener(Player player, NmsPacketListener listener) {
+        Objects.requireNonNull(player, "player cannot be null");
+        Objects.requireNonNull(listener, "listener cannot be null");
+
+        executeOnPipelineInEventLoop(player, pipeline -> {
+            if (pipeline.get(PACKET_HANDLER_NAME) != null) {
+                pipeline.remove(PACKET_HANDLER_NAME);
+            }
+            pipeline.addBefore("packet_handler", PACKET_HANDLER_NAME, new InboundPacketHandler(player, listener));
+        });
+    }
+
+    @Override
+    public void unregisterPacketListener(Player player) {
+        Objects.requireNonNull(player, "player cannot be null");
+
+        executeOnPipelineInEventLoop(player, pipeline -> {
+            if (pipeline.get(PACKET_HANDLER_NAME) != null) {
+                pipeline.remove(PACKET_HANDLER_NAME);
+            }
+        });
+    }
+
+    private void executeOnPipelineInEventLoop(Player player, Consumer<ChannelPipeline> task) {
+        ChannelPipeline pipeline = getPipeline(player);
+        EventLoop eventLoop = pipeline.channel().eventLoop();
+
+        if (eventLoop.inEventLoop()) {
+            executeOnPipeline(player, task, pipeline);
+        } else {
+            eventLoop.execute(() -> executeOnPipeline(player, task, pipeline));
+        }
+    }
+
+    private ChannelPipeline getPipeline(Player player) {
+        PlayerConnection playerConnection = ((CraftPlayer) player).getHandle().g;
+        NetworkManager networkManager = NETWORK_MANAGER_FIELD.get(playerConnection);
+        return networkManager.n.pipeline();
+    }
+
+    private void executeOnPipeline(Player player, Consumer<ChannelPipeline> task, ChannelPipeline pipeline) {
+        if (!player.isOnline()) {
+            return;
+        }
+
+        try {
+            task.accept(pipeline);
+        } catch (NoSuchElementException e) {
+            List<String> handlers = pipeline.names();
+            if (handlers.size() == 1 && handlers.getFirst().equals(DEFAULT_PIPELINE_TAIL)) {
+                // player disconnected immediately after joining
+                return;
+            }
+            throwFailedToModifyPipelineException(player, e);
+        } catch (Exception e) {
+            throwFailedToModifyPipelineException(player, e);
+        }
+    }
+
+    private void throwFailedToModifyPipelineException(Player player, Exception e) {
+        throw new DecentHologramsNmsException("Failed to modify player's pipeline. player: " + player.getName(), e);
+    }
+
+}

--- a/nms/nms-v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/v1_21_R6/PacketDataSerializerWrapper.java
+++ b/nms/nms-v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/v1_21_R6/PacketDataSerializerWrapper.java
@@ -1,0 +1,42 @@
+package eu.decentsoftware.holograms.nms.v1_21_R6;
+
+import io.netty.buffer.Unpooled;
+import net.minecraft.network.PacketDataSerializer;
+
+class PacketDataSerializerWrapper {
+
+    private static final ThreadLocal<PacketDataSerializerWrapper> LOCAL_INSTANCE = ThreadLocal.withInitial(
+            PacketDataSerializerWrapper::new);
+    private final PacketDataSerializer serializer;
+
+    private PacketDataSerializerWrapper() {
+        this.serializer = new PacketDataSerializer(Unpooled.buffer());
+    }
+
+    PacketDataSerializer getSerializer() {
+        return serializer;
+    }
+
+    void clear() {
+        serializer.clear();
+    }
+
+    void writeIntArray(int[] array) {
+        serializer.a(array);
+    }
+
+    void writeVarInt(int value) {
+        serializer.c(value);
+    }
+
+    int readVarInt() {
+        return serializer.l();
+    }
+
+    static PacketDataSerializerWrapper getInstance() {
+        PacketDataSerializerWrapper instance = LOCAL_INSTANCE.get();
+        instance.clear();
+        return instance;
+    }
+
+}

--- a/nms/nms-v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/v1_21_R6/SmallHeadHologramRenderer.java
+++ b/nms/nms-v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/v1_21_R6/SmallHeadHologramRenderer.java
@@ -1,0 +1,11 @@
+package eu.decentsoftware.holograms.nms.v1_21_R6;
+
+import eu.decentsoftware.holograms.nms.api.renderer.NmsSmallHeadHologramRenderer;
+
+class SmallHeadHologramRenderer extends HeadHologramRenderer implements NmsSmallHeadHologramRenderer {
+
+    SmallHeadHologramRenderer(EntityIdGenerator entityIdGenerator) {
+        super(entityIdGenerator, true);
+    }
+
+}

--- a/nms/nms-v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/v1_21_R6/TextHologramRenderer.java
+++ b/nms/nms-v1_21_R6/src/main/java/eu/decentsoftware/holograms/nms/v1_21_R6/TextHologramRenderer.java
@@ -1,0 +1,68 @@
+package eu.decentsoftware.holograms.nms.v1_21_R6;
+
+import eu.decentsoftware.holograms.nms.api.NmsHologramPartData;
+import eu.decentsoftware.holograms.nms.api.renderer.NmsTextHologramRenderer;
+import eu.decentsoftware.holograms.shared.DecentPosition;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+
+class TextHologramRenderer implements NmsTextHologramRenderer {
+
+    private final int armorStandEntityId;
+
+    TextHologramRenderer(EntityIdGenerator entityIdGenerator) {
+        this.armorStandEntityId = entityIdGenerator.getFreeEntityId();
+    }
+
+    @Override
+    public void display(Player player, NmsHologramPartData<String> data) {
+        String content = data.getContent();
+        DecentPosition position = data.getPosition();
+        EntityPacketsBuilder.create()
+                .withSpawnEntity(armorStandEntityId, EntityType.ARMOR_STAND, offsetPosition(position))
+                .withEntityMetadata(armorStandEntityId, EntityMetadataBuilder.create()
+                        .withInvisible()
+                        .withNoGravity()
+                        .withArmorStandProperties(true, true)
+                        .withCustomName(content)
+                        .toWatchableObjects())
+                .sendTo(player);
+    }
+
+    @Override
+    public void updateContent(Player player, NmsHologramPartData<String> data) {
+        EntityPacketsBuilder.create()
+                .withEntityMetadata(armorStandEntityId, EntityMetadataBuilder.create()
+                        .withCustomName(data.getContent())
+                        .toWatchableObjects())
+                .sendTo(player);
+    }
+
+    @Override
+    public void move(Player player, NmsHologramPartData<String> data) {
+        EntityPacketsBuilder.create()
+                .withTeleportEntity(armorStandEntityId, offsetPosition(data.getPosition()))
+                .sendTo(player);
+    }
+
+    @Override
+    public void hide(Player player) {
+        EntityPacketsBuilder.create()
+                .withRemoveEntity(armorStandEntityId)
+                .sendTo(player);
+    }
+
+    @Override
+    public double getHeight(NmsHologramPartData<String> data) {
+        return 0.25d;
+    }
+
+    @Override
+    public int[] getEntityIds() {
+        return new int[]{armorStandEntityId};
+    }
+
+    private DecentPosition offsetPosition(DecentPosition position) {
+        return position.subtractY(0.5);
+    }
+}

--- a/plugin/src/main/java/eu/decentsoftware/holograms/api/utils/reflect/Platform.java
+++ b/plugin/src/main/java/eu/decentsoftware/holograms/api/utils/reflect/Platform.java
@@ -1,0 +1,10 @@
+package eu.decentsoftware.holograms.api.utils.reflect;
+
+/**
+ * Enum of server platforms
+ */
+public enum Platform {
+    SPIGOT,
+    PAPER,
+    ALL
+}

--- a/plugin/src/main/java/eu/decentsoftware/holograms/api/utils/reflect/Version.java
+++ b/plugin/src/main/java/eu/decentsoftware/holograms/api/utils/reflect/Version.java
@@ -1,5 +1,6 @@
 package eu.decentsoftware.holograms.api.utils.reflect;
 
+import eu.decentsoftware.holograms.shared.reflect.ReflectUtil;
 import lombok.NonNull;
 import org.bukkit.Bukkit;
 
@@ -10,36 +11,38 @@ import javax.annotation.Nullable;
  */
 @SuppressWarnings("java:S115") // SonarLint: Enum values naming convention
 public enum Version {
-    v1_8_R1(8, "1.8"),
-    v1_8_R2(8, "1.8.3"),
-    v1_8_R3(8, "1.8.4", "1.8.5", "1.8.6", "1.8.7", "1.8.8"),
-    v1_9_R1(9, "1.9", "1.9.2"),
-    v1_9_R2(9, "1.9.4"),
-    v1_10_R1(10, "1.10", "1.10.2"),
-    v1_11_R1(11, "1.11", "1.11.1", "1.11.2"),
-    v1_12_R1(12, "1.12", "1.12.1", "1.12.2"),
-    v1_13_R1(13, "1.13"),
-    v1_13_R2(13, "1.13.1", "1.13.2"),
-    v1_14_R1(14, "1.14", "1.14.1", "1.14.2", "1.14.3", "1.14.4"),
-    v1_15_R1(15, "1.15", "1.15.1", "1.15.2"),
-    v1_16_R1(16, "1.16", "1.16.1"),
-    v1_16_R2(16, "1.16.2", "1.16.3"),
-    v1_16_R3(16, "1.16.4", "1.16.5"),
-    v1_17_R1(17, "1.17", "1.17.1"),
-    v1_18_R1(18, "1.18", "1.18.1"),
-    v1_18_R2(18, "1.18.2"),
-    v1_19_R1(19, "1.19", "1.19.1", "1.19.2"),
-    v1_19_R2(19, "1.19.3"),
-    v1_19_R3(19, "1.19.4"),
-    v1_20_R1(20, "1.20", "1.20.1"),
-    v1_20_R2(20, "1.20.2"),
-    v1_20_R3(20, "1.20.3", "1.20.4"),
-    v1_20_R4(20, "1.20.5", "1.20.6"),
-    v1_21_R1(21, "1.21", "1.21.1"),
-    v1_21_R2(21, "1.21.2", "1.21.3"),
-    v1_21_R3(21, "1.21.4"),
-    v1_21_R4(21, "1.21.5"),
-    v1_21_R5(21, "1.21.6", "1.21.7", "1.21.8"),
+    v1_8_R1(8, Platform.ALL,"1.8"),
+    v1_8_R2(8, Platform.ALL, "1.8.3"),
+    v1_8_R3(8, Platform.ALL, "1.8.4", "1.8.5", "1.8.6", "1.8.7", "1.8.8"),
+    v1_9_R1(9, Platform.ALL, "1.9", "1.9.2"),
+    v1_9_R2(9, Platform.ALL, "1.9.4"),
+    v1_10_R1(10, Platform.ALL, "1.10", "1.10.2"),
+    v1_11_R1(11, Platform.ALL, "1.11", "1.11.1", "1.11.2"),
+    v1_12_R1(12, Platform.ALL, "1.12", "1.12.1", "1.12.2"),
+    v1_13_R1(13, Platform.ALL, "1.13"),
+    v1_13_R2(13, Platform.ALL, "1.13.1", "1.13.2"),
+    v1_14_R1(14, Platform.ALL, "1.14", "1.14.1", "1.14.2", "1.14.3", "1.14.4"),
+    v1_15_R1(15, Platform.ALL, "1.15", "1.15.1", "1.15.2"),
+    v1_16_R1(16, Platform.ALL, "1.16", "1.16.1"),
+    v1_16_R2(16, Platform.ALL, "1.16.2", "1.16.3"),
+    v1_16_R3(16, Platform.ALL, "1.16.4", "1.16.5"),
+    v1_17_R1(17, Platform.ALL, "1.17", "1.17.1"),
+    v1_18_R1(18, Platform.ALL, "1.18", "1.18.1"),
+    v1_18_R2(18, Platform.ALL, "1.18.2"),
+    v1_19_R1(19, Platform.ALL, "1.19", "1.19.1", "1.19.2"),
+    v1_19_R2(19, Platform.ALL, "1.19.3"),
+    v1_19_R3(19, Platform.ALL, "1.19.4"),
+    v1_20_R1(20, Platform.ALL, "1.20", "1.20.1"),
+    v1_20_R2(20, Platform.ALL, "1.20.2"),
+    v1_20_R3(20, Platform.ALL, "1.20.3", "1.20.4"),
+    v1_20_R4(20, Platform.ALL, "1.20.5", "1.20.6"),
+    v1_21_R1(21, Platform.ALL, "1.21", "1.21.1"),
+    v1_21_R2(21, Platform.ALL, "1.21.2", "1.21.3"),
+    v1_21_R3(21, Platform.ALL, "1.21.4"),
+    v1_21_R4(21, Platform.ALL, "1.21.5"),
+    v1_21_R5(21, Platform.ALL, "1.21.6", "1.21.7", "1.21.8"),
+    v1_21_R6(21, Platform.SPIGOT, "1.21.9"),
+    paper_v1_21_R6(21, Platform.PAPER, "1.21.9")
     ;
 
     /*
@@ -47,15 +50,21 @@ public enum Version {
      */
 
     public static final Version CURRENT;
+    public static final Platform CURRENT_SERVER_PLATFORM;
     public static final String CURRENT_MINECRAFT_VERSION;
 
     static {
+        CURRENT_SERVER_PLATFORM = getServerPlatform();
         CURRENT_MINECRAFT_VERSION = getCurrentMinecraftVersion();
         CURRENT = getCurrentVersion();
     }
 
     private static Version getCurrentVersion() {
-        return fromMinecraftVersion(CURRENT_MINECRAFT_VERSION);
+        return fromMinecraftVersion(CURRENT_MINECRAFT_VERSION, CURRENT_SERVER_PLATFORM);
+    }
+
+    private static Platform getServerPlatform() {
+        return (ReflectUtil.isPaper) ? Platform.PAPER : Platform.SPIGOT;
     }
 
     private static String getCurrentMinecraftVersion() {
@@ -86,11 +95,13 @@ public enum Version {
     }
 
     @Nullable
-    public static Version fromMinecraftVersion(String minecraftVersion) {
+    public static Version fromMinecraftVersion(String minecraftVersion, Platform currentPlatform) {
         for (Version version : Version.values()) {
-            for (String candidateMinecraftVersion : version.getMinecraftVersions()) {
-                if (candidateMinecraftVersion.equals(minecraftVersion)) {
-                    return version;
+            if(version.platform.equals(Platform.ALL) || version.platform.equals(currentPlatform)) {
+                for (String candidateMinecraftVersion : version.getMinecraftVersions()) {
+                    if (candidateMinecraftVersion.equals(minecraftVersion)) {
+                        return version;
+                    }
                 }
             }
         }
@@ -146,10 +157,12 @@ public enum Version {
      */
 
     private final int minor;
+    private final Platform platform;
     private final String[] minecraftVersions;
 
-    Version(int minor, String... minecraftVersions) {
+    Version(int minor, Platform platform, String... minecraftVersions) {
         this.minor = minor;
+        this.platform = platform;
         this.minecraftVersions = minecraftVersions;
     }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,6 +16,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
+}
+
 rootProject.name = 'DecentHolograms'
 
 include ':shared'
@@ -52,3 +56,5 @@ include ':nms:nms-v1_21_R2'
 include ':nms:nms-v1_21_R3'
 include ':nms:nms-v1_21_R4'
 include ':nms:nms-v1_21_R5'
+include ':nms:nms-v1_21_R6'
+include ':nms:nms-paper_v1_21_R6'

--- a/shared/src/main/java/eu/decentsoftware/holograms/shared/reflect/ReflectField.java
+++ b/shared/src/main/java/eu/decentsoftware/holograms/shared/reflect/ReflectField.java
@@ -8,6 +8,11 @@ public class ReflectField<T> {
     private final String fieldName;
     private Field field;
 
+    public ReflectField(Class<?> clazz, String fieldName, String paperName) {
+        this.parentClass = clazz;
+        this.fieldName = ReflectUtil.isPaper ? paperName : fieldName;
+    }
+
     public ReflectField(Class<?> clazz, String fieldName) {
         this.parentClass = clazz;
         this.fieldName = fieldName;

--- a/shared/src/main/java/eu/decentsoftware/holograms/shared/reflect/ReflectUtil.java
+++ b/shared/src/main/java/eu/decentsoftware/holograms/shared/reflect/ReflectUtil.java
@@ -8,8 +8,30 @@ import java.lang.reflect.Field;
 // Never make this class final! (mocking)
 public class ReflectUtil {
 
+    public static boolean isPaper = false;
+
+    static {
+        try {
+            ReflectUtil.getClass("io.papermc.paper.PaperBootstrap");
+            isPaper = true;
+        } catch (ClassNotFoundException ignored) {}
+    }
+
     private ReflectUtil() {
         throw new IllegalAccessError("Utility class");
+    }
+
+    /**
+     * Get the value of a static field in a class.
+     *
+     * @param clazz     The class that has the field.
+     * @param fieldName The name of the field.
+*    * @param paperName The name of the paper (mojmap) field
+     * @param <T>       Type of the field.
+     * @return The value of the field.
+     */
+    public static <T> T getFieldValue(Class<?> clazz, String fieldName, String paperName) {
+        return getFieldValue(clazz, isPaper ? paperName : fieldName);
     }
 
     /**


### PR DESCRIPTION
Paper is soon removing the Spigot ossifications when splitting. 

I have updated Spigot and Paper to both 1.21.9 and split the packages.

Realistically because Paper uses Mojang mappings this should be easier to maintain in the future....

For those wanting to test the 1.21.9 build you can download it here - https://github.com/CapeCraft/DecentHolograms/releases/tag/1.21.9