### PR TITLE
Thread safe plugin availability checks

### DIFF
--- a/plugin/src/main/java/eu/decentsoftware/holograms/api/DecentHolograms.java
+++ b/plugin/src/main/java/eu/decentsoftware/holograms/api/DecentHolograms.java
@@ -15,6 +15,7 @@ import eu.decentsoftware.holograms.api.utils.event.EventFactory;
 import eu.decentsoftware.holograms.api.utils.reflect.Version;
 import eu.decentsoftware.holograms.api.utils.tick.Ticker;
 import eu.decentsoftware.holograms.event.DecentHologramsReloadEvent;
+import eu.decentsoftware.holograms.integration.IntegrationAvailabilityService;
 import eu.decentsoftware.holograms.nms.DecentHologramsNmsPacketListener;
 import eu.decentsoftware.holograms.nms.NmsAdapterFactory;
 import eu.decentsoftware.holograms.nms.NmsPacketListenerService;
@@ -45,6 +46,7 @@ public final class DecentHolograms {
 
     private final JavaPlugin plugin;
     private NmsAdapter nmsAdapter;
+    private IntegrationAvailabilityService integrationAvailabilityService;
     private NmsPacketListenerService nmsPacketListenerService;
     private HologramManager hologramManager;
     private CommandManager commandManager;
@@ -63,6 +65,9 @@ public final class DecentHolograms {
         Settings.reload();
         Lang.reload();
 
+        PluginManager pluginManager = Bukkit.getPluginManager();
+        this.integrationAvailabilityService = new IntegrationAvailabilityService(plugin, pluginManager);
+        this.integrationAvailabilityService.initialize();
         this.ticker = new Ticker();
         this.hologramManager = new HologramManager(this);
         this.commandManager = new CommandManager();
@@ -71,9 +76,8 @@ public final class DecentHolograms {
         DecentHologramsNmsPacketListener nmsPacketListener = new DecentHologramsNmsPacketListener(hologramManager);
         this.nmsPacketListenerService = new NmsPacketListenerService(plugin, nmsAdapter, nmsPacketListener);
 
-        PluginManager pm = Bukkit.getPluginManager();
-        pm.registerEvents(new PlayerListener(this), this.plugin);
-        pm.registerEvents(new WorldListener(hologramManager), this.plugin);
+        pluginManager.registerEvents(new PlayerListener(this), this.plugin);
+        pluginManager.registerEvents(new WorldListener(hologramManager), this.plugin);
 
         setupMetrics();
         checkForUpdates();
@@ -92,6 +96,7 @@ public final class DecentHolograms {
             hologram.destroy();
         }
 
+        this.integrationAvailabilityService.shutdown();
         BungeeUtils.destroy();
     }
 

--- a/plugin/src/main/java/eu/decentsoftware/holograms/api/utils/PAPI.java
+++ b/plugin/src/main/java/eu/decentsoftware/holograms/api/utils/PAPI.java
@@ -1,8 +1,8 @@
 package eu.decentsoftware.holograms.api.utils;
 
+import eu.decentsoftware.holograms.integration.Integration;
 import lombok.experimental.UtilityClass;
 import me.clip.placeholderapi.PlaceholderAPI;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 import java.util.List;
@@ -17,7 +17,7 @@ public class PAPI {
      * @return True if PlaceholderAPI is available.
      */
     public static boolean isAvailable() {
-        return Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI");
+        return Integration.PLACEHOLDER_API.isAvailable();
     }
 
     /**
@@ -42,7 +42,7 @@ public class PAPI {
     }
 
     /**
-     * Set placeholders to given List of Strings for given Player.
+     * Set placeholders to the given List of Strings for a given Player.
      *
      * @param player     The player.
      * @param stringList The string list.

--- a/plugin/src/main/java/eu/decentsoftware/holograms/api/utils/items/HologramItem.java
+++ b/plugin/src/main/java/eu/decentsoftware/holograms/api/utils/items/HologramItem.java
@@ -5,6 +5,7 @@ import eu.decentsoftware.holograms.api.utils.Log;
 import eu.decentsoftware.holograms.api.utils.PAPI;
 import eu.decentsoftware.holograms.api.utils.reflect.Version;
 import eu.decentsoftware.holograms.hook.NbtApiHook;
+import eu.decentsoftware.holograms.integration.Integration;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.apache.commons.lang.StringUtils;
@@ -46,7 +47,7 @@ public class HologramItem {
             if (material.name().contains("SKULL") || material.name().contains("HEAD")) {
                 String extrasFinal = parseExtras(player);
                 if (StringUtils.isNotEmpty(extrasFinal)) {
-                    if (extrasFinal.startsWith("HEADDATABASE_") && Bukkit.getPluginManager().isPluginEnabled("HeadDatabase")) {
+                    if (extrasFinal.startsWith("HEADDATABASE_") && Integration.HEAD_DATABASE.isAvailable()) {
                         String headDatabaseId = extrasFinal.substring("HEADDATABASE_".length());
                         itemBuilder.withItemStack(HeadDatabaseUtils.getHeadItemStackById(headDatabaseId));
                     } else if (extrasFinal.length() <= 16) {

--- a/plugin/src/main/java/eu/decentsoftware/holograms/integration/Integration.java
+++ b/plugin/src/main/java/eu/decentsoftware/holograms/integration/Integration.java
@@ -1,0 +1,78 @@
+/*
+ * This file is part of DecentHolograms, licensed under the GNU GPL v3.0 License.
+ * Copyright (C) DecentSoftware.eu
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package eu.decentsoftware.holograms.integration;
+
+import eu.decentsoftware.holograms.api.DecentHologramsAPI;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Represents external plugin integrations that can be used for additional functionality.
+ *
+ * @author d0by
+ * @since 2.9.9
+ */
+public enum Integration {
+    PLACEHOLDER_API("PlaceholderAPI"),
+    HEAD_DATABASE("HeadDatabase");
+
+    private final String pluginName;
+
+    Integration(String pluginName) {
+        this.pluginName = pluginName;
+    }
+
+    /**
+     * Get the plugin name.
+     *
+     * @return Plugin name.
+     * @since 2.9.9
+     */
+    public String getPluginName() {
+        return pluginName;
+    }
+
+    /**
+     * Check if integration is available.
+     *
+     * @return True if integration is available, false otherwise.
+     * @see IntegrationAvailabilityService
+     * @since 2.9.9
+     */
+    public boolean isAvailable() {
+        IntegrationAvailabilityService integrationAvailabilityService = DecentHologramsAPI.get().getIntegrationAvailabilityService();
+        return integrationAvailabilityService.isIntegrationAvailable(this);
+    }
+
+    /**
+     * Get integration by plugin name.
+     *
+     * @param pluginName Name of the plugin.
+     * @return Integration or null if not found.
+     * @since 2.9.9
+     */
+    @Nullable
+    public static Integration getByPluginName(String pluginName) {
+        for (Integration integration : values()) {
+            if (integration.getPluginName().equalsIgnoreCase(pluginName)) {
+                return integration;
+            }
+        }
+        return null;
+    }
+}

--- a/plugin/src/main/java/eu/decentsoftware/holograms/integration/IntegrationAvailabilityListener.java
+++ b/plugin/src/main/java/eu/decentsoftware/holograms/integration/IntegrationAvailabilityListener.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of DecentHolograms, licensed under the GNU GPL v3.0 License.
+ * Copyright (C) DecentSoftware.eu
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package eu.decentsoftware.holograms.integration;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.server.PluginDisableEvent;
+import org.bukkit.event.server.PluginEnableEvent;
+import org.bukkit.plugin.Plugin;
+
+/**
+ * Listener for integration availability events.
+ *
+ * <p>This listener is responsible for handling Plugin Enable & Disable events
+ * and update the integration availability cache accordingly.</p>
+ *
+ * @author d0by
+ * @see IntegrationAvailabilityService
+ * @since 2.9.9
+ */
+class IntegrationAvailabilityListener implements Listener {
+
+    private final IntegrationAvailabilityService service;
+
+    IntegrationAvailabilityListener(IntegrationAvailabilityService service) {
+        this.service = service;
+    }
+
+    @EventHandler
+    void onPluginEnable(PluginEnableEvent event) {
+        updateIntegrationAvailability(event.getPlugin(), true);
+    }
+
+    @EventHandler
+    void onPluginDisable(PluginDisableEvent event) {
+        updateIntegrationAvailability(event.getPlugin(), false);
+    }
+
+    private void updateIntegrationAvailability(Plugin plugin, boolean available) {
+        String pluginName = plugin.getName();
+        Integration integration = Integration.getByPluginName(pluginName);
+        if (integration != null) {
+            service.setIntegrationAvailability(integration, available);
+        }
+    }
+}

--- a/plugin/src/main/java/eu/decentsoftware/holograms/integration/IntegrationAvailabilityService.java
+++ b/plugin/src/main/java/eu/decentsoftware/holograms/integration/IntegrationAvailabilityService.java
@@ -1,0 +1,139 @@
+/*
+ * This file is part of DecentHolograms, licensed under the GNU GPL v3.0 License.
+ * Copyright (C) DecentSoftware.eu
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package eu.decentsoftware.holograms.integration;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.Bukkit;
+import org.bukkit.event.HandlerList;
+import org.bukkit.plugin.PluginManager;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Service that keeps track of the availability of integrations.
+ *
+ * @author d0by
+ * @since 2.9.9
+ */
+public class IntegrationAvailabilityService {
+
+    private final Map<Integration, AtomicBoolean> integrationsAvailability = new EnumMap<>(Integration.class);
+    private final JavaPlugin plugin;
+    private final PluginManager pluginManager;
+    private final IntegrationAvailabilityListener integrationAvailabilityListener;
+    private boolean initialized = false;
+
+    /**
+     * Create a new instance of {@link IntegrationAvailabilityService}.
+     *
+     * @param pluginManager The server's plugin manager.
+     * @since 2.9.9
+     */
+    public IntegrationAvailabilityService(JavaPlugin plugin, PluginManager pluginManager) {
+        Preconditions.checkNotNull(plugin, "plugin cannot be null");
+        Preconditions.checkNotNull(pluginManager, "pluginManager cannot be null");
+        this.plugin = plugin;
+        this.pluginManager = pluginManager;
+        this.integrationAvailabilityListener = new IntegrationAvailabilityListener(this);
+    }
+
+    /**
+     * Initializes the availability of integrations on startup.
+     *
+     * <p>This method must be called from the Main thread.</p>
+     *
+     * @throws IllegalStateException If this method is called from a non-Main thread.
+     * @throws IllegalStateException If this service has already been initialized.
+     * @since 2.9.9
+     */
+    public void initialize() {
+        if (!Bukkit.isPrimaryThread()) {
+            throw new IllegalStateException("This method must be called from the Main thread.");
+        }
+        if (initialized) {
+            throw new IllegalStateException("IntegrationAvailabilityService has already been initialized.");
+        }
+
+        initialized = true;
+        populateInitialAvailabilities();
+        pluginManager.registerEvents(integrationAvailabilityListener, plugin);
+    }
+
+    private void populateInitialAvailabilities() {
+        for (Integration integration : Integration.values()) {
+            boolean available = pluginManager.isPluginEnabled(integration.getPluginName());
+            integrationsAvailability.put(integration, new AtomicBoolean(available));
+        }
+    }
+
+    /**
+     * Shuts down the service.
+     *
+     * <p>This method should only be called when the plugin is being disabled.</p>
+     *
+     * @since 2.9.9
+     */
+    public void shutdown() {
+        HandlerList.unregisterAll(integrationAvailabilityListener);
+    }
+
+    /**
+     * Checks if an integration is available.
+     *
+     * <p>This method can be called asynchronously.</p>
+     *
+     * @param integration The integration to check.
+     * @return True if the integration is available, false otherwise.
+     * @see Integration
+     * @since 2.9.9
+     */
+    public boolean isIntegrationAvailable(Integration integration) {
+        Preconditions.checkNotNull(integration, "integration cannot be null");
+        checkInitialized();
+
+        AtomicBoolean availabilityStatus = integrationsAvailability.get(integration);
+        return availabilityStatus != null && availabilityStatus.get();
+    }
+
+    /**
+     * Sets the availability of an integration.
+     *
+     * @param integration The integration.
+     * @param available   True if the integration is available, false otherwise.
+     * @since 2.9.9
+     */
+    void setIntegrationAvailability(Integration integration, boolean available) {
+        Preconditions.checkNotNull(integration, "integration cannot be null");
+        checkInitialized();
+
+        AtomicBoolean availabilityStatus = integrationsAvailability.get(integration);
+        if (availabilityStatus != null) {
+            availabilityStatus.set(available);
+        }
+    }
+
+    private void checkInitialized() {
+        if (!initialized) {
+            throw new IllegalStateException("IntegrationAvailabilityService has not been initialized.");
+        }
+    }
+}

--- a/plugin/src/main/java/eu/decentsoftware/holograms/plugin/commands/LineSubCommand.java
+++ b/plugin/src/main/java/eu/decentsoftware/holograms/plugin/commands/LineSubCommand.java
@@ -15,6 +15,7 @@ import eu.decentsoftware.holograms.api.utils.Common;
 import eu.decentsoftware.holograms.api.utils.entity.DecentEntityType;
 import eu.decentsoftware.holograms.api.utils.items.DecentMaterial;
 import eu.decentsoftware.holograms.api.utils.message.Message;
+import eu.decentsoftware.holograms.integration.Integration;
 import eu.decentsoftware.holograms.plugin.Validator;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -823,7 +824,6 @@ public class LineSubCommand extends DecentCommand {
 				case "#HEAD:":
 				case "#SMALLHEAD:":
 					return TabCompleteHandler.getPartialMatches(args[1], items);
-				
 				case "#ENTITY:":
 					return TabCompleteHandler.getPartialMatches(args[1], DecentEntityType.getAllowedEntityTypeNames());
 			}
@@ -833,15 +833,14 @@ public class LineSubCommand extends DecentCommand {
 				List<String> names = Bukkit.getOnlinePlayers().stream()
 					.map(player -> "(" + player.getName() + ")")
 					.collect(Collectors.toList());
-				
-				if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
+
+				if (Integration.PLACEHOLDER_API.isAvailable()) {
 					names.add("(%player_name%)");
 				}
-				
-				if (Bukkit.getPluginManager().isPluginEnabled("HeadDatabase")) {
+				if (Integration.HEAD_DATABASE.isAvailable()) {
 					names.add("(HEADDATABASE_<id>)");
 				}
-				
+
 				return TabCompleteHandler.getPartialMatches(args[args.length - 1], names);
 			}
 			
@@ -850,7 +849,6 @@ public class LineSubCommand extends DecentCommand {
 				return Collections.singletonList("!ENCHANTED");
 			}
 		}
-		
 		return Collections.emptyList();
 	}
 	

--- a/plugin/src/test/java/eu/decentsoftware/holograms/api/utils/PAPITest.java
+++ b/plugin/src/test/java/eu/decentsoftware/holograms/api/utils/PAPITest.java
@@ -18,10 +18,12 @@
 
 package eu.decentsoftware.holograms.api.utils;
 
+import eu.decentsoftware.holograms.api.DecentHolograms;
+import eu.decentsoftware.holograms.api.DecentHologramsAPI;
+import eu.decentsoftware.holograms.integration.Integration;
+import eu.decentsoftware.holograms.integration.IntegrationAvailabilityService;
 import me.clip.placeholderapi.PlaceholderAPI;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
-import org.bukkit.plugin.PluginManager;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,12 +33,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class PAPITest {
 
     @Mock
-    private PluginManager pluginManager;
+    private DecentHolograms plugin;
+    @Mock
+    private IntegrationAvailabilityService integrationAvailabilityService;
     @Mock
     private Player player;
 
@@ -47,10 +52,12 @@ class PAPITest {
 
     @Test
     void testSetPlaceholders_PlaceholderAPINotEnabled() {
-        try (MockedStatic<Bukkit> mockedBukkit = mockStatic(Bukkit.class);
+        try (MockedStatic<DecentHologramsAPI> mockedDecentHologramsAPI = mockStatic(DecentHologramsAPI.class);
              MockedStatic<PlaceholderAPI> mockedPlaceholderAPI = mockStatic(PlaceholderAPI.class)) {
-            mockedBukkit.when(Bukkit::getPluginManager).thenReturn(pluginManager);
-            mockedBukkit.when(() -> pluginManager.isPluginEnabled("PlaceholderAPI")).thenReturn(false);
+            mockedDecentHologramsAPI.when(DecentHologramsAPI::get).thenReturn(plugin);
+            when(plugin.getIntegrationAvailabilityService()).thenReturn(integrationAvailabilityService);
+            when(integrationAvailabilityService.isIntegrationAvailable(Integration.PLACEHOLDER_API))
+                    .thenReturn(false);
 
             String result = PAPI.setPlaceholders(player, "Test %placeholder%");
 
@@ -61,10 +68,12 @@ class PAPITest {
 
     @Test
     void testSetPlaceholders_PlaceholderAPIThrows() {
-        try (MockedStatic<Bukkit> mockedBukkit = mockStatic(Bukkit.class);
+        try (MockedStatic<DecentHologramsAPI> mockedDecentHologramsAPI = mockStatic(DecentHologramsAPI.class);
              MockedStatic<PlaceholderAPI> mockedPlaceholderAPI = mockStatic(PlaceholderAPI.class)) {
-            mockedBukkit.when(Bukkit::getPluginManager).thenReturn(pluginManager);
-            mockedBukkit.when(() -> pluginManager.isPluginEnabled("PlaceholderAPI")).thenReturn(true);
+            mockedDecentHologramsAPI.when(DecentHologramsAPI::get).thenReturn(plugin);
+            when(plugin.getIntegrationAvailabilityService()).thenReturn(integrationAvailabilityService);
+            when(integrationAvailabilityService.isIntegrationAvailable(Integration.PLACEHOLDER_API))
+                    .thenReturn(true);
             mockedPlaceholderAPI.when(() -> PlaceholderAPI.setPlaceholders(player, "Test %placeholder%"))
                     .thenThrow(new RuntimeException("PlaceholderAPI exception"));
 
@@ -77,10 +86,12 @@ class PAPITest {
 
     @Test
     void testSetPlaceholders() {
-        try (MockedStatic<Bukkit> mockedBukkit = mockStatic(Bukkit.class);
+        try (MockedStatic<DecentHologramsAPI> mockedDecentHologramsAPI = mockStatic(DecentHologramsAPI.class);
              MockedStatic<PlaceholderAPI> mockedPlaceholderAPI = mockStatic(PlaceholderAPI.class)) {
-            mockedBukkit.when(Bukkit::getPluginManager).thenReturn(pluginManager);
-            mockedBukkit.when(() -> pluginManager.isPluginEnabled("PlaceholderAPI")).thenReturn(true);
+            mockedDecentHologramsAPI.when(DecentHologramsAPI::get).thenReturn(plugin);
+            when(plugin.getIntegrationAvailabilityService()).thenReturn(integrationAvailabilityService);
+            when(integrationAvailabilityService.isIntegrationAvailable(Integration.PLACEHOLDER_API))
+                    .thenReturn(true);
             mockedPlaceholderAPI.when(() -> PlaceholderAPI.setPlaceholders(player, "Test %placeholder%"))
                     .thenReturn("Test replaced");
 

--- a/plugin/src/test/java/eu/decentsoftware/holograms/integration/IntegrationAvailabilityListenerTest.java
+++ b/plugin/src/test/java/eu/decentsoftware/holograms/integration/IntegrationAvailabilityListenerTest.java
@@ -1,0 +1,86 @@
+/*
+ * This file is part of DecentHolograms, licensed under the GNU GPL v3.0 License.
+ * Copyright (C) DecentSoftware.eu
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package eu.decentsoftware.holograms.integration;
+
+import org.bukkit.event.server.PluginDisableEvent;
+import org.bukkit.event.server.PluginEnableEvent;
+import org.bukkit.plugin.Plugin;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class IntegrationAvailabilityListenerTest {
+
+    @Mock
+    private IntegrationAvailabilityService integrationAvailabilityService;
+    @InjectMocks
+    private IntegrationAvailabilityListener listener;
+
+    @Test
+    void testOnPluginEnable() {
+        PluginEnableEvent event = new PluginEnableEvent(createPlugin(Integration.PLACEHOLDER_API.getPluginName()));
+
+        listener.onPluginEnable(event);
+
+        verify(integrationAvailabilityService).setIntegrationAvailability(Integration.PLACEHOLDER_API, true);
+    }
+
+    @Test
+    void testOnPluginDisable() {
+        PluginDisableEvent event = new PluginDisableEvent(createPlugin(Integration.PLACEHOLDER_API.getPluginName()));
+
+        listener.onPluginDisable(event);
+
+        verify(integrationAvailabilityService).setIntegrationAvailability(Integration.PLACEHOLDER_API, false);
+    }
+
+    @Test
+    void testOnPluginEnable_unknownPlugin() {
+        PluginEnableEvent event = new PluginEnableEvent(createPlugin("unknownPlugin"));
+
+        listener.onPluginEnable(event);
+
+        verify(integrationAvailabilityService, never()).setIntegrationAvailability(any(), anyBoolean());
+    }
+
+    @Test
+    void testOnPluginDisable_unknownPlugin() {
+        PluginDisableEvent event = new PluginDisableEvent(createPlugin("unknownPlugin"));
+
+        listener.onPluginDisable(event);
+
+        verify(integrationAvailabilityService, never()).setIntegrationAvailability(any(), anyBoolean());
+    }
+
+    private static Plugin createPlugin(String pluginName) {
+        Plugin plugin = mock(Plugin.class);
+        when(plugin.getName()).thenReturn(pluginName);
+        return plugin;
+    }
+}

--- a/plugin/src/test/java/eu/decentsoftware/holograms/integration/IntegrationAvailabilityServiceTest.java
+++ b/plugin/src/test/java/eu/decentsoftware/holograms/integration/IntegrationAvailabilityServiceTest.java
@@ -1,0 +1,186 @@
+/*
+ * This file is part of DecentHolograms, licensed under the GNU GPL v3.0 License.
+ * Copyright (C) DecentSoftware.eu
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package eu.decentsoftware.holograms.integration;
+
+import org.bukkit.Bukkit;
+import org.bukkit.event.HandlerList;
+import org.bukkit.plugin.PluginManager;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class IntegrationAvailabilityServiceTest {
+
+    @Mock
+    private JavaPlugin plugin;
+    @Mock
+    private PluginManager pluginManager;
+    @InjectMocks
+    private IntegrationAvailabilityService service;
+
+    private static Object[][] provideInvalidParamsForConstruction() {
+        return new Object[][]{
+                {null, mock(PluginManager.class), "plugin cannot be null"},
+                {mock(JavaPlugin.class), null, "pluginManager cannot be null"},
+                {null, null, "plugin cannot be null"},
+        };
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidParamsForConstruction")
+    void testConstruction_invalidParams(JavaPlugin plugin, PluginManager pluginManager, String expectedMessage) {
+        NullPointerException exception = assertThrows(NullPointerException.class,
+                () -> new IntegrationAvailabilityService(plugin, pluginManager));
+
+        assertEquals(expectedMessage, exception.getMessage());
+    }
+
+    @Test
+    void testInitialize() {
+        when(pluginManager.isPluginEnabled(anyString())).thenReturn(true);
+
+        try (MockedStatic<Bukkit> mockedBukkit = mockStatic(Bukkit.class)) {
+            mockedBukkit.when(Bukkit::isPrimaryThread).thenReturn(true);
+
+            service.initialize();
+
+            for (Integration integration : Integration.values()) {
+                boolean isAvailable = service.isIntegrationAvailable(integration);
+                assertTrue(isAvailable, "Integration " + integration + " should be available after initialization.");
+                verify(pluginManager).isPluginEnabled(integration.getPluginName());
+            }
+            verify(pluginManager).registerEvents(any(IntegrationAvailabilityListener.class), eq(plugin));
+        }
+    }
+
+    @Test
+    void testInitialize_notPrimaryThread() {
+        try (MockedStatic<Bukkit> mockedBukkit = mockStatic(Bukkit.class)) {
+            mockedBukkit.when(Bukkit::isPrimaryThread).thenReturn(false);
+
+            IllegalStateException exception = assertThrows(IllegalStateException.class, service::initialize);
+
+            assertEquals("This method must be called from the Main thread.", exception.getMessage());
+            verifyNoInteractions(pluginManager);
+        }
+    }
+
+    @Test
+    void testInitialize_alreadyInitialized() {
+        when(pluginManager.isPluginEnabled(anyString())).thenReturn(true);
+
+        try (MockedStatic<Bukkit> mockedBukkit = mockStatic(Bukkit.class)) {
+            mockedBukkit.when(Bukkit::isPrimaryThread).thenReturn(true);
+
+            // Initialize once
+            service.initialize();
+
+            // Attempt to initialize again
+            IllegalStateException exception = assertThrows(IllegalStateException.class, service::initialize);
+
+            assertEquals("IntegrationAvailabilityService has already been initialized.", exception.getMessage());
+        }
+    }
+
+    @Test
+    void testShutdown() {
+        try (MockedStatic<HandlerList> mockedHandlerList = mockStatic(HandlerList.class)) {
+            service.shutdown();
+
+            mockedHandlerList.verify(() -> HandlerList.unregisterAll(any(IntegrationAvailabilityListener.class)));
+        }
+    }
+
+    @Test
+    void testIsIntegrationAvailable_notInitialized() {
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> service.isIntegrationAvailable(Integration.PLACEHOLDER_API));
+
+        assertEquals("IntegrationAvailabilityService has not been initialized.", exception.getMessage());
+    }
+
+    @Test
+    void testIsIntegrationAvailable_nullIntegration() {
+        try (MockedStatic<Bukkit> mockedBukkit = mockStatic(Bukkit.class)) {
+            mockedBukkit.when(Bukkit::isPrimaryThread).thenReturn(true);
+
+            service.initialize();
+            NullPointerException exception = assertThrows(NullPointerException.class, () -> service.isIntegrationAvailable(null));
+
+            assertEquals("integration cannot be null", exception.getMessage());
+        }
+    }
+
+    @Test
+    void testSetIntegrationAvailability_notInitialized() {
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> service.setIntegrationAvailability(Integration.PLACEHOLDER_API, true));
+
+        assertEquals("IntegrationAvailabilityService has not been initialized.", exception.getMessage());
+    }
+
+    @Test
+    void testSetIntegrationAvailability_nullIntegration() {
+        try (MockedStatic<Bukkit> mockedBukkit = mockStatic(Bukkit.class)) {
+            mockedBukkit.when(Bukkit::isPrimaryThread).thenReturn(true);
+
+            service.initialize();
+            NullPointerException exception = assertThrows(NullPointerException.class,
+                    () -> service.setIntegrationAvailability(null, true));
+
+            assertEquals("integration cannot be null", exception.getMessage());
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testSetIntegrationAvailability(boolean available) {
+        when(pluginManager.isPluginEnabled(anyString())).thenReturn(!available); // Opposite initial state
+
+        try (MockedStatic<Bukkit> mockedBukkit = mockStatic(Bukkit.class)) {
+            mockedBukkit.when(Bukkit::isPrimaryThread).thenReturn(true);
+
+            service.initialize();
+            service.setIntegrationAvailability(Integration.PLACEHOLDER_API, available);
+
+            assertEquals(available, service.isIntegrationAvailable(Integration.PLACEHOLDER_API));
+            assertEquals(!available, service.isIntegrationAvailable(Integration.HEAD_DATABASE)); // Other integrations are unaffected
+        }
+    }
+}

--- a/plugin/src/test/java/eu/decentsoftware/holograms/integration/IntegrationTest.java
+++ b/plugin/src/test/java/eu/decentsoftware/holograms/integration/IntegrationTest.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of DecentHolograms, licensed under the GNU GPL v3.0 License.
+ * Copyright (C) DecentSoftware.eu
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package eu.decentsoftware.holograms.integration;
+
+import eu.decentsoftware.holograms.api.DecentHolograms;
+import eu.decentsoftware.holograms.api.DecentHologramsAPI;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class IntegrationTest {
+
+    private static Object[][] provideIntegrationsAndPluginNames() {
+        return new Object[][]{
+                {Integration.PLACEHOLDER_API, "PlaceholderAPI"},
+                {Integration.HEAD_DATABASE, "HeadDatabase"},
+        };
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideIntegrationsAndPluginNames")
+    void testGetByPluginName(Integration integration, String pluginName) {
+        assertEquals(2, Integration.values().length, "New integration added without updating this test!");
+        assertEquals(integration, Integration.getByPluginName(pluginName));
+    }
+
+    @Test
+    void testGetByPluginName_invalidName() {
+        assertNull(Integration.getByPluginName("invalidName"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testIsAvailable(boolean available) {
+        DecentHolograms plugin = mock(DecentHolograms.class);
+        IntegrationAvailabilityService service = mock(IntegrationAvailabilityService.class);
+
+        try (MockedStatic<DecentHologramsAPI> mockedDecentHologramsAPI = mockStatic(DecentHologramsAPI.class)) {
+            mockedDecentHologramsAPI.when(DecentHologramsAPI::get).thenReturn(plugin);
+            when(plugin.getIntegrationAvailabilityService()).thenReturn(service);
+            when(service.isIntegrationAvailable(Integration.PLACEHOLDER_API)).thenReturn(available);
+
+            assertEquals(available, Integration.PLACEHOLDER_API.isAvailable());
+        }
+    }
+}


### PR DESCRIPTION
We recently encountered issues with calling `PluginManager#isPluginAvailable` asynchronously, as it can lead to deadlocks (see #365).

To address this, this PR introduces `IntegrationAvailabilityService`. The service maintains an up-to-date, thread-safe view of which external plugins are currently available on the server.

`PluginManager#isPluginAvailable` is invoked only once during plugin enable, and strictly on the main thread. From that point on, the availability state is kept in sync using Bukkit’s `PluginEnableEvent` and `PluginDisableEvent`, avoiding any asynchronous access to Bukkit internals.

At the moment, the service only tracks `PlaceholderAPI` and `HeadDatabase`, but can be extended in the future as needed.