### PR TITLE
Reduce object allocations

### DIFF
--- a/plugin/src/main/java/eu/decentsoftware/holograms/api/animations/AnimationManager.java
+++ b/plugin/src/main/java/eu/decentsoftware/holograms/api/animations/AnimationManager.java
@@ -28,6 +28,7 @@ public class AnimationManager extends Ticked {
     private final DecentHolograms decentHolograms;
     private final Map<String, TextAnimation> animationMap = new HashMap<>();
     private final AtomicLong step;
+    private final ThreadLocal<Matcher> matcherCache = ThreadLocal.withInitial(() -> ANIMATION_PATTERN.matcher(""));
 
     public AnimationManager(DecentHolograms decentHolograms) {
         super(1L);
@@ -66,7 +67,8 @@ public class AnimationManager extends Ticked {
 
     @NonNull
     public String parseTextAnimations(@NonNull String string) {
-        Matcher matcher = ANIMATION_PATTERN.matcher(string);
+        Matcher matcher = matcherCache.get().reset(string);
+
         while (matcher.find()) {
             String animationName = matcher.group(1);
             String args = matcher.group(2);
@@ -89,8 +91,7 @@ public class AnimationManager extends Ticked {
     }
 
     public boolean containsAnimations(@NonNull String string) {
-        Matcher matcher = ANIMATION_PATTERN.matcher(string);
-        return matcher.find() || string.contains("&u");
+        return string.contains("&u") || matcherCache.get().reset(string).find();
     }
 
     public TextAnimation registerAnimation(@NonNull String name, @NonNull TextAnimation animation) {

--- a/plugin/src/main/java/eu/decentsoftware/holograms/api/holograms/objects/HologramObject.java
+++ b/plugin/src/main/java/eu/decentsoftware/holograms/api/holograms/objects/HologramObject.java
@@ -1,6 +1,5 @@
 package eu.decentsoftware.holograms.api.holograms.objects;
 
-import com.google.common.collect.ImmutableSet;
 import eu.decentsoftware.holograms.api.holograms.DisableCause;
 import lombok.Getter;
 import lombok.NonNull;
@@ -9,11 +8,8 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 @Getter
 @Setter
@@ -151,7 +147,7 @@ public abstract class HologramObject extends FlagHolder {
      */
     @NonNull
     public Set<UUID> getViewers() {
-        return ImmutableSet.copyOf(viewers);
+        return Collections.unmodifiableSet(viewers);
     }
 
     /**
@@ -161,10 +157,14 @@ public abstract class HologramObject extends FlagHolder {
      */
     @NonNull
     public List<Player> getViewerPlayers() {
-        return getViewers().stream()
-                .map(Bukkit::getPlayer)
-                .filter(player -> player != null && player.isOnline())
-                .collect(Collectors.toList());
+        final List<Player> playerList = new ArrayList<>(viewers.size());
+        for (final UUID uuid : viewers) {
+            final Player player = Bukkit.getPlayer(uuid);
+            if (player != null && player.isOnline()) {
+                playerList.add(player);
+            }
+        }
+        return playerList;
     }
 
     /**


### PR DESCRIPTION
Changes:
Don't copy all viewers (ImmutableSet.copyOf) and use a wrapper class (Collections.unmodifiableSet)
Remove stream allocation and use for loop
Reuse the same Matcher object 