### PR TITLE
Fix wrong permission for /dh displays help

### DIFF
--- a/plugin/src/main/java/eu/decentsoftware/holograms/display/command/DisplaysHelpCommand.java
+++ b/plugin/src/main/java/eu/decentsoftware/holograms/display/command/DisplaysHelpCommand.java
@@ -27,7 +27,7 @@ import eu.decentsoftware.holograms.api.utils.Common;
 @CommandInfo(
         usage = "/dh d help",
         description = "Show general displays help.",
-        permissions = {"dh.display.command.help"},
+        permissions = {"dh.command.displays.help"},
         aliases = {"?"}
 )
 class DisplaysHelpCommand extends DecentCommand {


### PR DESCRIPTION
The `/dh displays help` command has an incorrect permission:
`dh.display.command.help` when it should be `dh.command.displays.help` like the other commands.