### PR TITLE
Save attribute-defaults.yml if missing

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/plugin/src/main/java/eu/decentsoftware/holograms/api/DecentHolograms.java
+++ b/plugin/src/main/java/eu/decentsoftware/holograms/api/DecentHolograms.java
@@ -71,6 +71,9 @@ public final class DecentHolograms {
         Settings.reload();
         Lang.reload();
 
+        // Save the default display attribute configuration if it does not exist.
+        saveDefaultAttributeDefaults();
+
         PluginManager pluginManager = Bukkit.getPluginManager();
         this.integrationAvailabilityService = new IntegrationAvailabilityService(plugin, pluginManager);
         this.integrationAvailabilityService.initialize();
@@ -94,7 +97,6 @@ public final class DecentHolograms {
 
         setupMetrics();
         checkForUpdates();
-
         BungeeUtils.init();
     }
 
@@ -125,6 +127,8 @@ public final class DecentHolograms {
         Settings.reload();
         Lang.reload();
 
+        // Save the default display attribute configuration if it was deleted or is missing.
+        saveDefaultAttributeDefaults();
         this.animationManager.reload();
         this.hologramManager.reload();
         this.featureManager.reload();
@@ -133,6 +137,27 @@ public final class DecentHolograms {
         }
 
         EventFactory.fireReloadEvent();
+    }
+
+    /**
+     * Saves attribute-defaults.yml from the plugin jar to the plugin data folder
+     * if the file does not already exist.
+     * This prevents the warning:
+     * "No attribute defaults file found. Skipping."
+     */
+    private void saveDefaultAttributeDefaults() {
+        File file = new File(plugin.getDataFolder(), "attribute-defaults.yml");
+
+        if (file.exists()) {
+            return;
+        }
+
+        try {
+            plugin.saveResource("attribute-defaults.yml", false);
+            Log.info("Saved default attribute-defaults.yml.");
+        } catch (IllegalArgumentException e) {
+            Log.warn("Could not save attribute-defaults.yml because it was not found inside the plugin jar.");
+        }
     }
 
     private void initializeNmsAdapter() {
@@ -185,5 +210,4 @@ public final class DecentHolograms {
     public Logger getLogger() {
         return plugin.getLogger();
     }
-
 }


### PR DESCRIPTION
Saves the default attribute-defaults.yml resource to the plugin data folder when it is missing.
This prevents the display attribute defaults loader from logging: "No attribute defaults file found. Skipping."
Existing user configuration is not overwritten.

Upgraded Gradle-wrapper version to 9.5.0