### PR TITLE
Add setting to move/create display on eye-level

### DIFF
--- a/plugin/src/main/java/eu/decentsoftware/holograms/api/Settings.java
+++ b/plugin/src/main/java/eu/decentsoftware/holograms/api/Settings.java
@@ -79,6 +79,16 @@ public class Settings {
             .put("[P]", "\u2022")
             .put("[|]", "\u23B9")
             .build();
+    
+    /**
+     * Set this to true if you want Display Holograms to appear at the player's eye level.
+     *
+     * <p>When enabled, Display Holograms will be positioned at the player's eye height when created or moved.</p>
+     *
+     * <p>When disabled, Display holograms will be positioned at the player's feet height when created or moved (default).</p>
+     */
+    @Key("displays-eye-level-positioning")
+    public static boolean DISPLAYS_EYE_LEVEL_POSITIONING = false;
 
     // ========================================= //
 

--- a/plugin/src/main/java/eu/decentsoftware/holograms/display/command/CreateDisplayCommand.java
+++ b/plugin/src/main/java/eu/decentsoftware/holograms/display/command/CreateDisplayCommand.java
@@ -19,6 +19,7 @@
 package eu.decentsoftware.holograms.display.command;
 
 import eu.decentsoftware.holograms.api.Lang;
+import eu.decentsoftware.holograms.api.Settings;
 import eu.decentsoftware.holograms.api.commands.CommandHandler;
 import eu.decentsoftware.holograms.api.commands.CommandInfo;
 import eu.decentsoftware.holograms.api.commands.DecentCommand;
@@ -87,7 +88,8 @@ class CreateDisplayCommand extends DecentCommand {
                 return true;
             }
 
-            Location location = ((Player) sender).getLocation();
+            final Player player = (Player) sender;
+            Location location = Settings.DISPLAYS_EYE_LEVEL_POSITIONING ? player.getEyeLocation() : player.getLocation();
             DisplayBase display = createDisplay(type, name, args, fromBukkitLocation(location));
             attributeDefaultService.applyDefaultValues(display);
             displayService.saveDisplay(display);

--- a/plugin/src/main/java/eu/decentsoftware/holograms/display/command/MoveHereDisplayCommand.java
+++ b/plugin/src/main/java/eu/decentsoftware/holograms/display/command/MoveHereDisplayCommand.java
@@ -19,6 +19,7 @@
 package eu.decentsoftware.holograms.display.command;
 
 import eu.decentsoftware.holograms.api.Lang;
+import eu.decentsoftware.holograms.api.Settings;
 import eu.decentsoftware.holograms.api.commands.CommandHandler;
 import eu.decentsoftware.holograms.api.commands.CommandInfo;
 import eu.decentsoftware.holograms.api.commands.DecentCommand;
@@ -54,7 +55,8 @@ class MoveHereDisplayCommand extends DecentCommand {
             DisplayBase display = Validator.getDisplay(displayService, args[0]);
 
             DecentLocation displayLocation = display.getLocation();
-            Location playerLocation = ((Player) sender).getLocation();
+            final Player player = (Player) sender;
+            Location playerLocation = Settings.DISPLAYS_EYE_LEVEL_POSITIONING ? player.getEyeLocation() : player.getLocation();
             display.setLocation(new DecentLocation(
                     playerLocation.getWorld().getName(),
                     playerLocation.getX(),

--- a/plugin/src/main/resources/config.yml
+++ b/plugin/src/main/resources/config.yml
@@ -70,6 +70,11 @@ update-visibility-on-teleport: false
 # When disabled, holograms will be positioned at the player's feet height when created or moved (default).
 holograms-eye-level-positioning: false
 
+# Set this to true if you want Display holograms to appear at the player's eye level.
+# When enabled, Display holograms will be positioned at the player's eye height when created or moved.
+# When disabled, Display holograms will be positioned at the player's feet height when created or moved (default).
+displays-eye-level-positioning: false
+
 #
 # Sets the time in seconds that DecentHolograms should have when trying to fetch Skin data for players both
 # by name and UUID.


### PR DESCRIPTION
Added a new config option `displays-eye-level-positioning`

This, when true, makes display holograms always move/spawn at the player's eye level instead of their feet, similar to normal holograms.