### PR TITLE
🐛 Correct Y-coordinate calculation for clickable entities.

### DIFF
--- a/plugin/src/main/java/eu/decentsoftware/holograms/api/holograms/Hologram.java
+++ b/plugin/src/main/java/eu/decentsoftware/holograms/api/holograms/Hologram.java
@@ -808,7 +808,7 @@ public class Hologram extends UpdatingHologramObject implements ITicked {
         // Spawn clickable entities
         int amount = (int) (page.getHeight() / 2) + 1;
         Location location = getLocation().clone();
-        location.setY((int) (location.getY() - (isDownOrigin() ? 0 : page.getHeight())) + 0.5);
+        location.setY((int) (location.getY() - (isDownOrigin() ? 0 : page.getHeight())) - 1d);
         for (int i = 0; i < amount; i++) {
             NmsClickableHologramRenderer renderer = page.getClickableRenderer(i);
             renderer.display(player, DecentPosition.fromBukkitLocation(location));


### PR DESCRIPTION
According to my extensive testing on Paper 1.21.11, offsetting it by +0.5, as was done previously, causes it to resemble a passenger and places it directly above the other armour stand. This makes the hitbox for actions uncomfortable at the top. Currently, I am not aware of a way to change this.

This commit changes it to the same height as the text itself and works for down origin HGs and normal ones. This is important for a good user experience. The armour stands are still not in the same positions, so the hitbox starts at the text and goes above it. In the long term, another idea would be to use the same entity as the text.

This change isn't needed on all setups and in some it makes it actually behaving worse. 