### PR TITLE
Fix legacy color parsing on 1.16

### DIFF
--- a/nms/nms-v1_16_R1/src/main/java/eu/decentsoftware/holograms/nms/v1_16_R1/LegacyTextFormattingParserImpl.java
+++ b/nms/nms-v1_16_R1/src/main/java/eu/decentsoftware/holograms/nms/v1_16_R1/LegacyTextFormattingParserImpl.java
@@ -40,7 +40,7 @@ final class LegacyTextFormattingParserImpl extends LegacyTextFormattingParser<IC
     static {
         String formattingChars = "0123456789ABCDEFKLMNORabcdefklmnor";
         for (char c : formattingChars.toCharArray()) {
-            FORMATS_BY_CHAR[c] = EnumChatFormat.a(c);
+            FORMATS_BY_CHAR[c] = getByChar(c);
         }
 
         // Just cache all combinations of special format flags for O(1) lookup
@@ -63,6 +63,16 @@ final class LegacyTextFormattingParserImpl extends LegacyTextFormattingParser<IC
             }
             FORMATS_BY_FLAGS[flags] = list.toArray(new EnumChatFormat[0]);
         }
+    }
+
+    private static EnumChatFormat getByChar(char c) {
+        char lowerCaseChar = Character.toLowerCase(c);
+        for (EnumChatFormat format : EnumChatFormat.values()) {
+            if (format.character == lowerCaseChar) {
+                return format;
+            }
+        }
+        return null;
     }
 
     @Override

--- a/nms/nms-v1_16_R2/src/main/java/eu/decentsoftware/holograms/nms/v1_16_R2/LegacyTextFormattingParserImpl.java
+++ b/nms/nms-v1_16_R2/src/main/java/eu/decentsoftware/holograms/nms/v1_16_R2/LegacyTextFormattingParserImpl.java
@@ -40,7 +40,7 @@ final class LegacyTextFormattingParserImpl extends LegacyTextFormattingParser<IC
     static {
         String formattingChars = "0123456789ABCDEFKLMNORabcdefklmnor";
         for (char c : formattingChars.toCharArray()) {
-            FORMATS_BY_CHAR[c] = EnumChatFormat.a(c);
+            FORMATS_BY_CHAR[c] = getByChar(c);
         }
 
         // Just cache all combinations of special format flags for O(1) lookup
@@ -63,6 +63,16 @@ final class LegacyTextFormattingParserImpl extends LegacyTextFormattingParser<IC
             }
             FORMATS_BY_FLAGS[flags] = list.toArray(new EnumChatFormat[0]);
         }
+    }
+
+    private static EnumChatFormat getByChar(char c) {
+        char lowerCaseChar = Character.toLowerCase(c);
+        for (EnumChatFormat format : EnumChatFormat.values()) {
+            if (format.character == lowerCaseChar) {
+                return format;
+            }
+        }
+        return null;
     }
 
     @Override

--- a/nms/nms-v1_16_R3/src/main/java/eu/decentsoftware/holograms/nms/v1_16_R3/LegacyTextFormattingParserImpl.java
+++ b/nms/nms-v1_16_R3/src/main/java/eu/decentsoftware/holograms/nms/v1_16_R3/LegacyTextFormattingParserImpl.java
@@ -40,7 +40,7 @@ final class LegacyTextFormattingParserImpl extends LegacyTextFormattingParser<IC
     static {
         String formattingChars = "0123456789ABCDEFKLMNORabcdefklmnor";
         for (char c : formattingChars.toCharArray()) {
-            FORMATS_BY_CHAR[c] = EnumChatFormat.a(c);
+            FORMATS_BY_CHAR[c] = getByChar(c);
         }
 
         // Just cache all combinations of special format flags for O(1) lookup
@@ -63,6 +63,16 @@ final class LegacyTextFormattingParserImpl extends LegacyTextFormattingParser<IC
             }
             FORMATS_BY_FLAGS[flags] = list.toArray(new EnumChatFormat[0]);
         }
+    }
+
+    private static EnumChatFormat getByChar(char c) {
+        char lowerCaseChar = Character.toLowerCase(c);
+        for (EnumChatFormat format : EnumChatFormat.values()) {
+            if (format.character == lowerCaseChar) {
+                return format;
+            }
+        }
+        return null;
     }
 
     @Override


### PR DESCRIPTION
## Summary

Fixes legacy color codes such as `&6[Secret]` rendering as `6[Secret]` on Minecraft 1.16.x.

## Cause

The 1.16.x `LegacyTextFormattingParserImpl` used `EnumChatFormat.a(c)` to resolve formatting characters. On 1.16.x this resolves to `a(int)`, not `a(char)`, so characters like `'6'` are interpreted as integer color indexes and return `null`.

The parser then skips `§` and leaves the formatting character visible.

## Fix

Resolve `EnumChatFormat` by comparing against the public `character` field in the 1.16.x implementations.

## Validation

```text
./gradlew.bat :nms:nms-v1_16_R1:compileJava :nms:nms-v1_16_R2:compileJava :nms:nms-v1_16_R3:compileJava
BUILD SUCCESSFUL