### PR TITLE
ci: verify NMS interaction classes are packaged

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,29 @@ jobs:
       - name: Build and Run Unit Tests
         run: ./gradlew build
 
+      - name: Verify NMS interaction classes are packaged
+        shell: bash
+        run: |
+          JAR="$(find plugin/build/libs -maxdepth 1 -type f -name 'DecentHolograms-*.jar' ! -name '*-sources.jar' -print -quit)"
+          if [ -z "$JAR" ]; then
+            echo "No distributable DecentHolograms jar was produced."
+            exit 1
+          fi
+
+          REQUIRED_CLASSES=(
+            "eu/decentsoftware/holograms/nms/api/event/NmsEntityInteractAction.class"
+            "eu/decentsoftware/holograms/nms/api/event/NmsEntityInteractEvent.class"
+            "eu/decentsoftware/holograms/nms/v26_2/InboundPacketHandler.class"
+          )
+
+          JAR_CONTENTS="$(jar tf "$JAR")"
+          for required_class in "${REQUIRED_CLASSES[@]}"; do
+            if ! grep -Fxq "$required_class" <<< "$JAR_CONTENTS"; then
+              echo "Missing required runtime class from $JAR: $required_class"
+              exit 1
+            fi
+          done
+
       - name: Verify Publishing
         run: ./gradlew publishToMavenLocal
 


### PR DESCRIPTION
This adds a CI check to verify that the distributable DecentHolograms jar contains the NMS classes required for entity and hologram interactions.

A Paper 26.2 server running DecentHolograms 2.10.1 produced the following disconnect when attacking a hologram:

```text
Internal Exception: java.lang.NoClassDefFoundError: eu/decentsoftware/holograms/nms/api/event/NmsEntityInteractAction
```

The affected class exists in the source tree and is referenced by the 26.2 inbound packet handler, so this adds a packaging regression check rather than changing interaction behavior.

CI now verifies that the final plugin jar contains:

* `NmsEntityInteractAction.class`
* `NmsEntityInteractEvent.class`
* `v26_2/InboundPacketHandler.class`

If any of these runtime classes are missing from the distributable jar, the build will fail instead of allowing an incomplete artifact to be published.
