### PR TITLE
feat: damage/heal feature event propagation and customization

### DIFF
--- a/plugin/src/main/java/eu/decentsoftware/holograms/event/TemporaryDamageHologramSpawnEvent.java
+++ b/plugin/src/main/java/eu/decentsoftware/holograms/event/TemporaryDamageHologramSpawnEvent.java
@@ -1,0 +1,45 @@
+package eu.decentsoftware.holograms.event;
+
+import lombok.Getter;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * This event is called when a temporary hologram is spawned, from the "damage display" feature.<br/>
+ * Cancelling the event will prevent the hologram from being spawned.
+ */
+@Getter
+public class TemporaryDamageHologramSpawnEvent extends TemporaryHologramSpawnEvent {
+
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    @Getter private final double amount;
+    @Getter private final @Nullable Entity damager;
+
+    /**
+     * New event instance.
+     * @param entity entity that has been damaged.
+     * @param text text of the hologram that will be spawned.
+     * @param location location of the hologram that will be spawned.
+     * @param amount amount of damage that has been done.
+     * @param damager the entity that caused the damage, can be null if the damage was not caused by an entity.
+     */
+    public TemporaryDamageHologramSpawnEvent(@NotNull Entity entity, @NotNull String text, @NotNull Location location, double amount, @Nullable Entity damager) {
+        super(entity, text, location);
+        this.amount = amount;
+        this.damager = damager;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+      return HANDLERS;
+    }
+
+    public static HandlerList getHandlerList() {
+      return HANDLERS;
+    }
+
+}

--- a/plugin/src/main/java/eu/decentsoftware/holograms/event/TemporaryHealHologramSpawnEvent.java
+++ b/plugin/src/main/java/eu/decentsoftware/holograms/event/TemporaryHealHologramSpawnEvent.java
@@ -1,0 +1,41 @@
+package eu.decentsoftware.holograms.event;
+
+import lombok.Getter;
+import org.bukkit.Location;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * This event is called when a temporary hologram is spawned, from the "healing display" feature.<br/>
+ * Cancelling the event will prevent the hologram from being spawned.
+ */
+@Getter
+public class TemporaryHealHologramSpawnEvent extends TemporaryHologramSpawnEvent {
+
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    @Getter private final double amount;
+
+  /**
+   * New event instance.
+   * @param livingEntity living entity that has been healed.
+   * @param text text of the hologram that will be spawned.
+   * @param amount amount of healing that has been done.
+   * @param location location of the hologram that will be spawned.
+   */
+    public TemporaryHealHologramSpawnEvent(@NotNull LivingEntity livingEntity, @NotNull String text, double amount, @NotNull Location location) {
+        super(livingEntity, text, location);
+        this.amount = amount;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+      return HANDLERS;
+    }
+
+    public static HandlerList getHandlerList() {
+      return HANDLERS;
+    }
+
+}

--- a/plugin/src/main/java/eu/decentsoftware/holograms/event/TemporaryHologramSpawnEvent.java
+++ b/plugin/src/main/java/eu/decentsoftware/holograms/event/TemporaryHologramSpawnEvent.java
@@ -1,0 +1,62 @@
+package eu.decentsoftware.holograms.event;
+
+import lombok.Getter;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Cancellable;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Abstract event class for temporary hologram spawn events. This class is extended by specific events such
+ * as TemporaryDamageHologramSpawnEvent and TemporaryHealHologramSpawnEvent.<br/>
+ *
+ * @author jamailun
+ */
+@Getter
+public abstract class TemporaryHologramSpawnEvent extends DecentHologramsEvent implements Cancellable {
+
+    private boolean cancelled = false;
+    private final @NotNull Entity entity;
+    private @NotNull String text;
+    private @NotNull Location location;
+
+    /**
+     * Constructor for the TemporaryHologramSpawnEvent.
+     * @param entity The entity associated with the event.
+     * @param text The text of the hologram that will be spawned.
+     * @param location The location of the hologram that will be spawned.
+     */
+    protected TemporaryHologramSpawnEvent(@NotNull Entity entity, @NotNull String text, @NotNull Location location) {
+        super(false);
+        this.entity = entity;
+        this.text = text;
+        this.location = location;
+    }
+
+    /**
+     * Sets the text of the hologram that will be spawned.
+     * @param text The text to set for the hologram.
+     */
+    public void setText(@NotNull String text) {
+        this.text = text;
+    }
+
+    /**
+     * Sets the location of the hologram that will be spawned.
+     * @param location The location to set for the hologram.
+     */
+    public void setLocation(@NotNull Location location) {
+        this.location = location;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+}

--- a/plugin/src/main/java/eu/decentsoftware/holograms/plugin/features/DamageDisplayFeature.java
+++ b/plugin/src/main/java/eu/decentsoftware/holograms/plugin/features/DamageDisplayFeature.java
@@ -5,7 +5,9 @@ import eu.decentsoftware.holograms.api.features.AbstractFeature;
 import eu.decentsoftware.holograms.api.holograms.HologramManager;
 import eu.decentsoftware.holograms.api.utils.config.FileConfig;
 import eu.decentsoftware.holograms.api.utils.location.LocationUtils;
+import eu.decentsoftware.holograms.event.TemporaryDamageHologramSpawnEvent;
 import lombok.NonNull;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.ArmorStand;
@@ -116,7 +118,13 @@ public class DamageDisplayFeature extends AbstractFeature implements Listener {
             currentAppearance = this.appearance;
         }
         String text = currentAppearance.replace("{damage}", FeatureCommons.formatNumber(damage));
-        hologramManager.spawnTemporaryHologramLine(location, text, duration);
+
+        // Propagate event to allow other plugins to modify or cancel the hologram spawn
+        TemporaryDamageHologramSpawnEvent event = new TemporaryDamageHologramSpawnEvent(entity, text, location, damage, damager);
+        Bukkit.getServer().getPluginManager().callEvent(event);
+        if ( ! event.isCancelled()) {
+            hologramManager.spawnTemporaryHologramLine(event.getLocation(), event.getText(), duration);
+        }
     }
 
     /**

--- a/plugin/src/main/java/eu/decentsoftware/holograms/plugin/features/HealingDisplayFeature.java
+++ b/plugin/src/main/java/eu/decentsoftware/holograms/plugin/features/HealingDisplayFeature.java
@@ -5,6 +5,8 @@ import eu.decentsoftware.holograms.api.features.AbstractFeature;
 import eu.decentsoftware.holograms.api.holograms.HologramManager;
 import eu.decentsoftware.holograms.api.utils.config.FileConfig;
 import eu.decentsoftware.holograms.api.utils.location.LocationUtils;
+import eu.decentsoftware.holograms.event.TemporaryHealHologramSpawnEvent;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Entity;
@@ -105,7 +107,13 @@ public class HealingDisplayFeature extends AbstractFeature implements Listener {
 
         Location location = LocationUtils.randomizeLocation(entity.getLocation().clone().add(0, 1 + heightOffset, 0));
         String text = appearance.replace("{heal}", FeatureCommons.formatNumber(heal));
-        hologramManager.spawnTemporaryHologramLine(location, text, duration);
+
+        // Propagate event to allow other plugins to modify or cancel the hologram spawn
+        TemporaryHealHologramSpawnEvent event = new TemporaryHealHologramSpawnEvent(livingEntity, text, heal, location);
+        Bukkit.getServer().getPluginManager().callEvent(event);
+        if ( ! event.isCancelled()) {
+            hologramManager.spawnTemporaryHologramLine(event.getLocation(), event.getText(), duration);
+        }
     }
 
 }


### PR DESCRIPTION
## Motivation

Allow for consumer plugins to customize the temporary holograms produced by the `DamageDisplayFeature` and  `HealingDisplayFeature`.

## Realisation

- New events exposed in the API : `TemporaryDamageHologramSpawnEvent` and  `TemporaryHealHologramSpawnEvent`.
- Both events are cancellable and allow any listening plugin to change the location and text of the temporary hologram.
- Events are emitted in the two `Feature` objects, and are called before creating the temporary hologram.

## Tests

Only tested in `1.21.11` for now.